### PR TITLE
Version as the result of %version, not through Display

### DIFF
--- a/src/Engines/BaseEngine.cs
+++ b/src/Engines/BaseEngine.cs
@@ -596,7 +596,8 @@ namespace Microsoft.Jupyter.Core
                 (Context.Properties.KernelName, Context.Properties.KernelVersion),
                 ("Jupyter Core", typeof(BaseEngine).Assembly.GetName().Version.ToString())
             };
-            channel.Display(
+
+            return
                 new Table<(string, string)>
                 {
                     Columns = new List<(string, Func<(string, string), string>)>
@@ -605,9 +606,7 @@ namespace Microsoft.Jupyter.Core
                         ("Version", item => item.Item2)
                     },
                     Rows = versions.ToList()
-                }
-            );
-            return ExecuteStatus.Ok.ToExecutionResult();
+                }.ToExecutionResult();
         }
 
         #endregion


### PR DESCRIPTION
I want to be able to programmatically get the kernel version from Python (to display it and add the package version), right now it just gets in the output directly; instead, returning as the return value of the Magic.