### PR TITLE
Install the kernel using the given executable name if the executable is not dotnet.

### DIFF
--- a/src/Data/Metadata.cs
+++ b/src/Data/Metadata.cs
@@ -68,8 +68,8 @@ namespace Microsoft.Jupyter.Core
         public string FriendlyName { get; set; }
 
         /// <summary>
-        ///     The command name for the kernel, such that the kernel can be
-        ///     invoked by <c>dotnet ${KernelName}</c>.
+        ///     The name for the kernel, this name will be used to register the kernel with Jupyter
+        ///     and to identify the kernel programmatically.
         /// </summary>
         public string KernelName { get; set; }
 

--- a/src/KernelApplication.cs
+++ b/src/KernelApplication.cs
@@ -376,7 +376,6 @@ namespace Microsoft.Jupyter.Core
                     {
                         kernelArgs.Add(System.Diagnostics.Process.GetCurrentProcess().MainModule.FileName);
                     }
-                    kernelArgs.AddRange(new[] { "dotnet", properties.KernelName });
                 }
 
                 kernelArgs.AddRange(


### PR DESCRIPTION
IQ# users have reported problems of dotnet finding global tools as subcommands in Ubuntu.
This change will install the kernel using the actual executable name to avoid this problem.