### PR TITLE
Fix #21 by better catching exception when Jupyter isn't installed.

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,3 +50,4 @@ This project has adopted the [Microsoft Open Source Code of Conduct](https://ope
 For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or
 contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.
 
+

--- a/src/KernelApplication.cs
+++ b/src/KernelApplication.cs
@@ -13,6 +13,7 @@ using Microsoft.Extensions.DependencyInjection;
 using System.Reflection;
 using System.Linq;
 using Microsoft.Jupyter.Core.Protocol;
+using System.ComponentModel;
 
 namespace Microsoft.Jupyter.Core
 {
@@ -423,12 +424,50 @@ namespace Microsoft.Jupyter.Core
             if (!String.IsNullOrWhiteSpace(prefix)) { extraArgs.Add($"--prefix=\"{prefix}\""); }
             if (user) { extraArgs.Add("--user"); }
 
-            var process = Process.Start(new ProcessStartInfo
+            Process process = null;
+            try
             {
-                FileName = "jupyter",
-                Arguments = $"kernelspec install {kernelSpecDir} --name=\"{properties.KernelName}\" {String.Join(" ", extraArgs)}"
-            });
-            process.WaitForExit();
+                process = Process.Start(new ProcessStartInfo
+                {
+                    FileName = "jupyter",
+                    Arguments = $"kernelspec install {kernelSpecDir} --name=\"{properties.KernelName}\" {String.Join(" ", extraArgs)}"
+                });
+            }
+            catch (Win32Exception ex)
+            {
+                System.Console.ForegroundColor = ConsoleColor.Red;
+                if (ex.NativeErrorCode == 2)
+                {
+                    System.Console.Error.WriteLine(
+                        "[ERROR] " +
+                        $"Could not install {properties.KernelName} into your Jupyter configuration, " +
+                        "as `jupyter` was not found on your PATH. " +
+                        "Please make sure that Jupyter is installed and is on your PATH. " +
+                        "If you are using conda or venv, please " +
+                        "make sure that you have the correct environment activated.\n"
+                    );
+                }
+                else
+                {
+                    System.Console.Error.WriteLine(
+                        "[ERROR] " +
+                        $"An exception occured while trying to call `jupyter` to install {properties.KernelName} " +
+                        "into your Jupyter configuration.\n"
+                    );
+                }
+                System.Console.ResetColor();
+                System.Console.Error.WriteLine(
+                    "Full exception details:\n" + ex.ToString()
+                );
+            }
+            catch (Exception ex)
+            {
+                System.Console.WriteLine(ex);
+                return -2;
+            }
+
+            process?.WaitForExit();
+
             foreach (var fileName in filesToDelete)
             {
                 try
@@ -438,7 +477,7 @@ namespace Microsoft.Jupyter.Core
                 catch { }
             }
             Directory.Delete(tempKernelSpecDir);
-            return process.ExitCode;
+            return process?.ExitCode ?? -1;
         }
 
 


### PR DESCRIPTION
This PR should fix #21 by catching exceptions when launching `jupyter kernelspec install` and reporting more useful error text. For some reason, .NET Core 2.2 doesn't actually throw `FileNotFoundException` as per documentation, but `Win32Exception` instead (even on Linux and macOS), so we catch that here and check the error code.