### PR TITLE
Ignore transient display data when missing.

### DIFF
--- a/src/Data/Protocol.cs
+++ b/src/Data/Protocol.cs
@@ -219,7 +219,7 @@ namespace Microsoft.Jupyter.Core.Protocol
         [JsonProperty("metadata")]
         public Dictionary<string, string> Metadata { get; set; } = new Dictionary<string, string>();
 
-        [JsonProperty("transient")]
+        [JsonProperty("transient", NullValueHandling=NullValueHandling.Ignore)]
         public TransientDisplayData Transient { get; set; } = null;
     }
 


### PR DESCRIPTION
This PR fixes #22 by instruction Newtonsoft.Json to suppress (ignore) transient display data when not provided, instead of writing out `null` for the transient display data.