### PR TITLE
Enable better logging on startup.

### DIFF
--- a/src/Data/ConnectionInfo.cs
+++ b/src/Data/ConnectionInfo.cs
@@ -118,5 +118,12 @@ namespace Microsoft.Jupyter.Core
         }
         #endregion
 
+        #region Diagnostic Support
+
+        public override string ToString() =>
+            JsonConvert.SerializeObject(this, Formatting.Indented);
+
+        #endregion
+
     }
 }

--- a/src/Data/KernelContext.cs
+++ b/src/Data/KernelContext.cs
@@ -5,6 +5,7 @@ using System;
 using System.IO;
 using System.Security.Cryptography;
 using System.Text;
+using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 
 namespace Microsoft.Jupyter.Core
@@ -26,9 +27,15 @@ namespace Microsoft.Jupyter.Core
         /// <param name="connectionFile">
         ///     A path to the connection file to be loaded.
         /// </param>
-        public void LoadConnectionFile(string connectionFile)
+        /// <param name="logger">
+        ///     A logger object used to report debugging information from the
+        ///     connection file.
+        /// </param>
+        public void LoadConnectionFile(string connectionFile, ILogger logger = null)
         {
+            logger?.LogDebug("Loading kernel context from connection file: {connectionFile}.", connectionFile);
             this.ConnectionInfo = JsonConvert.DeserializeObject<ConnectionInfo>(File.ReadAllText(connectionFile));
+            logger?.LogDebug("Loaded connection information:\n{connectionInfo}", this.ConnectionInfo);
         }
 
         internal HMAC NewHmac() {

--- a/src/Servers/ShellServer.cs
+++ b/src/Servers/ShellServer.cs
@@ -108,6 +108,7 @@ namespace Microsoft.Jupyter.Core
 
         private void EventLoop(NetMQSocket socket)
         {
+            this.logger.LogDebug("Starting shell server event loop at {Address}.", socket);
             while (alive)
             {
                 try


### PR DESCRIPTION
This PR allows kernel applications to listen to an environment variable for logging level, and provides additional diagnostic information on startup. The environment variable name is automatically generated from the kernel name, such that the example kernels can be configured using `$IECHO_LOG_LEVEL` and `$IMOON_LOG_LEVEL`, and such that IQ# can be configured using `$IQSHARP_LOG_LEVEL`.