### PR TITLE
Added custom shell message events.

### DIFF
--- a/src/Data/Protocol.cs
+++ b/src/Data/Protocol.cs
@@ -25,6 +25,7 @@ namespace Microsoft.Jupyter.Core.Protocol
         {
             ProtocolVersion = "5.2.0";
             Id = Guid.NewGuid().ToString();
+            Username = Environment.UserName;
         }
 
         [JsonProperty("msg_id")]

--- a/src/Data/Protocol.cs
+++ b/src/Data/Protocol.cs
@@ -66,7 +66,7 @@ namespace Microsoft.Jupyter.Core.Protocol
         // FIXME: make not just an object.
         public MessageContent Content { get; set; }
 
-        internal Message AsReplyTo(Message parent)
+        public Message AsReplyTo(Message parent)
         {
             // No parent, just return
             if (parent == null) return this;

--- a/src/Engines/BaseEngine.cs
+++ b/src/Engines/BaseEngine.cs
@@ -103,7 +103,7 @@ namespace Microsoft.Jupyter.Core
 
         /// <summary>
         /// This event is triggered when a magic command is executed. Magic commands are typically
-        /// identified by symbols that is pre-fixed with '%' (like <c>%history</c>).
+        /// identified by symbol    s that is pre-fixed with '%' (like <c>%history</c>).
         /// </summary>
         public event EventHandler<ExecutedEventArgs> MagicExecuted;
 
@@ -143,7 +143,8 @@ namespace Microsoft.Jupyter.Core
         public BaseEngine(
                 IShellServer shell,
                 IOptions<KernelContext> context,
-                ILogger logger)
+                ILogger logger
+        )
         {
             ExecutionCount = 0;
             this.ShellServer = shell;

--- a/src/Extensions/Messages.cs
+++ b/src/Extensions/Messages.cs
@@ -113,7 +113,7 @@ namespace Microsoft.Jupyter.Core
             //       message frames.
 
             var zmqMessage = new NetMQMessage();
-            var frames = new[] 
+            var frames = new[]
                 {
                     message.Header,
                     message.ParentHeader,

--- a/src/Extensions/ServiceCollection.cs
+++ b/src/Extensions/ServiceCollection.cs
@@ -22,7 +22,8 @@ namespace Microsoft.Jupyter.Core
         {
             serviceCollection
                 .AddSingleton<IHeartbeatServer, HeartbeatServer>()
-                .AddSingleton<IShellServer, ShellServer>();
+                .AddSingleton<IShellServer, ShellServer>()
+                .AddSingleton<IShellRouter, ShellRouter>();
 
             return serviceCollection;
         }

--- a/src/Servers/IShellServer.cs
+++ b/src/Servers/IShellServer.cs
@@ -12,6 +12,7 @@ namespace Microsoft.Jupyter.Core
         event Action<Message> ExecuteRequest;
 
         event Action<Message> ShutdownRequest;
+        event Action<Message> CustomRequest;
 
         void SendShellMessage(Message message);
 

--- a/src/Servers/IShellServer.cs
+++ b/src/Servers/IShellServer.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Text;
 using Microsoft.Jupyter.Core.Protocol;
@@ -12,7 +12,6 @@ namespace Microsoft.Jupyter.Core
         event Action<Message> ExecuteRequest;
 
         event Action<Message> ShutdownRequest;
-        event Action<Message> CustomRequest;
 
         void SendShellMessage(Message message);
 

--- a/src/Servers/ShellServer.cs
+++ b/src/Servers/ShellServer.cs
@@ -50,18 +50,25 @@ namespace Microsoft.Jupyter.Core
         private ILogger<ShellServer> logger;
         private KernelContext context;
         private IServiceProvider provider;
+        private IShellRouter router;
 
         private string session;
 
         public ShellServer(
             ILogger<ShellServer> logger,
             IOptions<KernelContext> context,
-            IServiceProvider provider
+            IServiceProvider provider,
+            IShellRouter router
         )
         {
             this.logger = logger;
             this.context = context.Value;
             this.provider = provider;
+            this.router = router;
+
+            router.RegisterHandler("kernel_info_request", message => KernelInfoRequest?.Invoke(message));
+            router.RegisterHandler("execute_request", message => ExecuteRequest?.Invoke(message));
+            router.RegisterHandler("shutdown_request", message => ShutdownRequest?.Invoke(message));
         }
 
         public void Start()
@@ -133,16 +140,7 @@ namespace Microsoft.Jupyter.Core
 
                     // Get a service that can handle the message type and
                     // dispatch.
-                    (
-                        nextMessage.Header.MessageType switch
-                        {
-                            "kernel_info_request" => KernelInfoRequest,
-                            "execute_request" => ExecuteRequest,
-                            "shutdown_request" => ShutdownRequest,
-                            _ => CustomRequest
-                        }
-                    )
-                    ?.Invoke(nextMessage);
+                    router.Handle(nextMessage);
                 }
                 catch (ProtocolViolationException ex)
                 {
@@ -161,7 +159,6 @@ namespace Microsoft.Jupyter.Core
         public event Action<Message> KernelInfoRequest;
         public event Action<Message> ExecuteRequest;
         public event Action<Message> ShutdownRequest;
-        public event Action<Message> CustomRequest;
 
         protected virtual void Dispose(bool disposing)
         {

--- a/src/Servers/ShellServer.cs
+++ b/src/Servers/ShellServer.cs
@@ -133,20 +133,16 @@ namespace Microsoft.Jupyter.Core
 
                     // Get a service that can handle the message type and
                     // dispatch.
-                    switch (nextMessage.Header.MessageType)
-                    {
-                        case "kernel_info_request":
-                            KernelInfoRequest?.Invoke(nextMessage);
-                            break;
-
-                        case "execute_request":
-                            ExecuteRequest?.Invoke(nextMessage);
-                            break;
-
-                        case "shutdown_request":
-                            ShutdownRequest?.Invoke(nextMessage);
-                            break;
-                    }
+                    (
+                        nextMessage.Header.MessageType switch
+                        {
+                            "kernel_info_request" => KernelInfoRequest,
+                            "execute_request" => ExecuteRequest,
+                            "shutdown_request" => ShutdownRequest,
+                            _ => CustomRequest
+                        }
+                    )
+                    ?.Invoke(nextMessage);
                 }
                 catch (ProtocolViolationException ex)
                 {
@@ -165,6 +161,7 @@ namespace Microsoft.Jupyter.Core
         public event Action<Message> KernelInfoRequest;
         public event Action<Message> ExecuteRequest;
         public event Action<Message> ShutdownRequest;
+        public event Action<Message> CustomRequest;
 
         protected virtual void Dispose(bool disposing)
         {

--- a/src/ShellRouting/IShellRouter.cs
+++ b/src/ShellRouting/IShellRouter.cs
@@ -1,0 +1,30 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Linq;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Jupyter.Core.Protocol;
+
+namespace Microsoft.Jupyter.Core
+{
+    public interface IShellHandler
+    {
+        public string MessageType { get; }
+        public void Handle(Message message);
+    }
+
+    public interface IShellRouter
+    {
+        public void RegisterHandler(string messageType, Action<Message> handler);
+
+        public void RegisterHandler(IShellHandler handler) =>
+            RegisterHandler(handler.MessageType, handler.Handle);
+
+        public void RegisterFallback(Action<Message> fallback);
+
+        public void Handle(Message message);
+
+        public void RegisterHandlers<TAssembly>();
+    }
+}

--- a/src/ShellRouting/IShellRouter.cs
+++ b/src/ShellRouting/IShellRouter.cs
@@ -8,23 +8,98 @@ using Microsoft.Jupyter.Core.Protocol;
 
 namespace Microsoft.Jupyter.Core
 {
+    /// <summary>
+    ///     Represents a class that can handle and respond to
+    ///     shell messages coming in from a client.
+    /// </summary>
     public interface IShellHandler
     {
+        /// <summary>
+        ///     The message type handled by this handler (e.g.: <c>kernel_info_request</c>).
+        /// </summary>
         public string MessageType { get; }
+        
+        /// <summary>
+        ///     Called by the shell server to handle a message coming in from the client.
+        /// </summary>
+        /// <param name="message">
+        ///     The incoming message to be handled.
+        /// </param>
         public void Handle(Message message);
     }
 
+    /// <summary>
+    ///     Represents a class that can be used to route incoming shell
+    ///     messages to appropriate handlers.
+    /// </summary>
     public interface IShellRouter
     {
+        /// <summary>
+        ///     Registers an action that can be used to handle a
+        ///     particular message type.
+        /// </summary>
+        /// <param name="messageType">
+        ///     The type of message to be handled.
+        /// </param>
+        /// <param name="handler">
+        ///     An action that can be used to handle incoming messages of
+        ///     type <c>messageType</c>.
+        /// </param>
+        /// <example>
+        ///     To register a handler that logs <c>ping_request</c>
+        ///     message IDs:
+        ///     <code><![CDATA[
+        ///         router.RegisterHandler(
+        ///             "ping_request"
+        ///             message => logger.LogDebug(
+        ///                 "Got ping_request with id {Id}.",
+        ///                 message.Header.Id
+        ///             )
+        ///         );
+        ///     ]]></code>
+        /// </example>
         public void RegisterHandler(string messageType, Action<Message> handler);
 
+        /// <summary>
+        ///     Registers a handler that can be used to handle a
+        ///     particular message type.
+        /// </summary>
+        /// <param name="handler">
+        ///     The handler to be registered; the
+        ///     <see cref="Microsoft.Jupyter.Core.IShellHandler.MessageType" />
+        ///     property of the handler will be used to define the
+        ///     message type to be handled.
+        /// </param>
         public void RegisterHandler(IShellHandler handler) =>
             RegisterHandler(handler.MessageType, handler.Handle);
 
+        /// <summary>
+        ///     Registers an action to be used to handle messages
+        ///     whose message types do not have appropriate handlers.
+        /// </summary>
+        /// <param name="fallback">
+        ///     An action that can be used to handle messages
+        ///     whose message types do not have appropriate handlers.
+        /// </param>
         public void RegisterFallback(Action<Message> fallback);
 
+        /// <summary>
+        ///     Calls the appropriate handler for a given message,
+        ///     or the fallback handler if no more appropriate handler
+        ///     exists.
+        /// </summary>
+        /// <param name="message">
+        ///     The message to be handled.
+        /// </param>
         public void Handle(Message message);
 
+        /// <summary>
+        ///     Searches an assembly for types representing shell
+        ///     handlers and registers each handler.
+        /// </summary>
+        /// <typeparam name="TAssembly">
+        ///     A type from the assembly to be searched.
+        /// </typeparam>
         public void RegisterHandlers<TAssembly>();
     }
 }

--- a/src/ShellRouting/ShellRouter.cs
+++ b/src/ShellRouting/ShellRouter.cs
@@ -1,0 +1,79 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Jupyter.Core.Protocol;
+
+namespace Microsoft.Jupyter.Core
+{
+
+    /// <summary>
+    ///     Routes shell messages to handlers based on the message type
+    ///     of each incoming shell messsge.
+    /// </summary>
+    public class ShellRouter : IShellRouter
+    {
+        private readonly IDictionary<string, Action<Message>> shellHandlers = new Dictionary<string, Action<Message>>();
+        private Action<Message> fallback;
+        private readonly ILogger<ShellRouter> logger;
+        private IServiceProvider services;
+
+        public ShellRouter(
+            IServiceProvider services,
+            ILogger<ShellRouter> logger
+        )
+        {
+            this.logger = logger;
+            this.services = services;
+
+            // Set a default fallback action.
+            RegisterFallback(message =>
+                logger.LogWarning("Unrecognized custom shell message of type {Type}: {Message}", message.Header.MessageType, message)
+            );
+        }
+
+        public void Handle(Message message) =>
+            (
+                shellHandlers.TryGetValue(message.Header.MessageType, out var handler)
+                ? handler : fallback
+            )(message);
+
+        public void RegisterHandler(string messageType, Action<Message> handler)
+        {
+            shellHandlers[messageType] = handler;
+        }
+
+        public void RegisterFallback(Action<Message> fallback) =>
+            this.fallback = fallback;
+
+        public void RegisterHandlers<TAssembly>()
+        {
+            var handlers = typeof(TAssembly)
+                .Assembly
+                .GetTypes()
+                .Where(t =>
+                {
+                    if (!t.IsClass && t.IsAbstract) { return false; }
+                    var matched = t
+                        .GetInterfaces()
+                        .Contains(typeof(IShellHandler));
+                    this.logger.LogDebug("Class {Class} subclass of CustomShellHandler? {Matched}", t.FullName, matched);
+                    return matched;
+                })
+                .Select(handlerType =>
+                    ActivatorUtilities.CreateInstance(services, handlerType)
+                )
+                .Cast<IShellHandler>();
+
+            foreach (var handler in handlers)
+            {
+                logger.LogInformation("Registering handler for type: {Type}", handler.MessageType);
+                ((IShellRouter) this).RegisterHandler(handler);
+            }
+        }
+    }
+}

--- a/src/ShellRouting/ShellRouter.cs
+++ b/src/ShellRouting/ShellRouter.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -27,6 +29,8 @@ namespace Microsoft.Jupyter.Core
             ILogger<ShellRouter> logger
         )
         {
+            if (services == null) { throw new ArgumentNullException(nameof(services)); }
+            if (logger == null) { throw new ArgumentNullException(nameof(logger)); }
             this.logger = logger;
             this.services = services;
 


### PR DESCRIPTION
This PR creates a new event on ShellServer that gets called for unrecognized messages on the shell port. That in turn allows us to extend functionality beyond built-in JMP functionality using client-side extensions, since the shell channel is exposed by Jupyter Notebook all the way through to JavaScript running in the document scope.