### PR TITLE
Allow for updatable display data.

### DIFF
--- a/examples/echo-kernel/EchoEngine.cs
+++ b/examples/echo-kernel/EchoEngine.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Collections.Generic;
 using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Logging;
+using System.Threading;
 
 namespace Microsoft.Jupyter.Core
 {
@@ -20,5 +21,24 @@ namespace Microsoft.Jupyter.Core
 
         public override ExecutionResult ExecuteMundane(string input, IChannel channel) =>
             (Program.ShoutOption.HasValue() ? input.ToUpper() : input).ToExecutionResult();
+
+        [MagicCommand(
+            "%tick",
+            "Writes some ticks to demonstrate updatable display data."
+        )]
+        public ExecutionResult ExecuteTick(string code, IChannel channel)
+        {
+            var tickMessage = "Tick.";
+            var updatable = channel.DisplayUpdatable(tickMessage);
+
+            foreach (var idx in Enumerable.Range(0, 10))
+            {
+                tickMessage += ".";
+                Thread.Sleep(1000);
+                updatable.Update(tickMessage);
+            }
+
+            return ExecuteStatus.Ok.ToExecutionResult();
+        }
     }
 }

--- a/src/Engines/BaseEngine.cs
+++ b/src/Engines/BaseEngine.cs
@@ -554,7 +554,7 @@ namespace Microsoft.Jupyter.Core
             return symbol != null;
         }
 
-        /// <summmary>
+        /// <summary>
         ///      Returns <c>true</c> if a given input is a request for help
         ///      on a symbol. If this method returns true, then <c>symbol</c>
         ///      will be populated with the resolution of the symbol targeted

--- a/src/Engines/BaseEngine.cs
+++ b/src/Engines/BaseEngine.cs
@@ -63,7 +63,8 @@ namespace Microsoft.Jupyter.Core
             ///     given output.
             /// </summary>
             /// <returns>
-            ///     A display ID that can be used to update the given output.
+            ///     An object that can be used to update the display in the
+            ///     future.
             /// </returns>
             public IUpdatableDisplay DisplayUpdatable(object displayable)
             {

--- a/src/Engines/BaseEngine.cs
+++ b/src/Engines/BaseEngine.cs
@@ -26,6 +26,22 @@ namespace Microsoft.Jupyter.Core
     /// </summary>
     public abstract class BaseEngine : IExecutionEngine
     {
+        private class UpdatableDisplay : IUpdatableDisplay
+        {
+            private ExecutionChannel channel;
+            private string displayId;
+
+            public UpdatableDisplay(ExecutionChannel channel, string displayId)
+            {
+                this.channel = channel;
+                this.displayId = displayId;
+            }
+
+            public void Update(object displayable)
+            {
+                channel.UpdateDisplay(displayable, displayId);
+            }
+        }
 
         private class ExecutionChannel : IChannel
         {
@@ -40,6 +56,32 @@ namespace Microsoft.Jupyter.Core
             public void Display(object displayable)
             {
                 engine.WriteDisplayData(parent, displayable);
+            }
+
+            /// <summary>
+            ///     Displays a given object, allowing for future updates to the
+            ///     given output.
+            /// </summary>
+            /// <returns>
+            ///     A display ID that can be used to update the given output.
+            /// </returns>
+            public IUpdatableDisplay DisplayUpdatable(object displayable)
+            {
+                var transient = new TransientDisplayData
+                {
+                    DisplayId = Guid.NewGuid().ToString()
+                };
+                engine.WriteDisplayData(parent, displayable, transient);
+                return new UpdatableDisplay(this, transient.DisplayId);
+            }
+
+            public void UpdateDisplay(object displayable, string displayId)
+            {
+                var transient = new TransientDisplayData
+                {
+                    DisplayId = displayId
+                };
+                engine.WriteDisplayData(parent, displayable, transient, isUpdate: true);
             }
 
             public void Stderr(string message)
@@ -315,7 +357,7 @@ namespace Microsoft.Jupyter.Core
             }
         }
 
-        private void WriteDisplayData(Message parent, object displayable)
+        private void WriteDisplayData(Message parent, object displayable, TransientDisplayData transient = null, bool isUpdate = false)
         {
             try
             {
@@ -327,13 +369,15 @@ namespace Microsoft.Jupyter.Core
                     {
                         Header = new MessageHeader
                         {
-                            MessageType = "display_data"
+                            MessageType = isUpdate
+                                          ? "update_display_data"
+                                          : "display_data"
                         },
                         Content = new DisplayDataContent
                         {
                             Data = serialized.Data,
                             Metadata = serialized.Metadata,
-                            Transient = null
+                            Transient = transient
                         }
                     }.AsReplyTo(parent)
                 );

--- a/src/Engines/IChannel.cs
+++ b/src/Engines/IChannel.cs
@@ -3,6 +3,11 @@
 
 namespace Microsoft.Jupyter.Core
 {
+    public interface IUpdatableDisplay
+    {
+        void Update(object displayable);
+    }
+
     /// <summary>
     ///      Specifies a display channel between a Jupyter kernel and its clients
     ///      that can be used for printing to streams and for displaying
@@ -27,5 +32,13 @@ namespace Microsoft.Jupyter.Core
         /// </summary>
         /// <param name="displayable">The object to be displayed. Cannot be null.</param>
         void Display(object displayable);
+
+        /// <summary>
+        ///     Displays an object using this display channel and allows for the
+        ///     object to be updated with future calls.
+        /// </summary>
+        /// <param name="displayable">The object to be displayed. Cannot be null.</param>
+        /// <returns>An object that can be used to update the display.</returns>
+        IUpdatableDisplay DisplayUpdatable(object displayable);
     }
 }

--- a/src/Engines/IChannel.cs
+++ b/src/Engines/IChannel.cs
@@ -3,8 +3,20 @@
 
 namespace Microsoft.Jupyter.Core
 {
+    /// <summary>
+    ///     Represents a display output that can be updated after it is first
+    ///     rendered (e.g.: for displaying progress of long-running tasks,
+    ///     or for providing interactivity with the user).
+    /// </summary>
     public interface IUpdatableDisplay
     {
+        /// <summary>
+        ///     Replaces any previous content rendered to this display with a
+        //      new displayable object.
+        /// </summary>
+        /// <param name="displayable">
+        ///     The object to be displayed. Cannot be null.
+        /// </param>
         void Update(object displayable);
     }
 

--- a/src/Engines/IChannel.cs
+++ b/src/Engines/IChannel.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Jupyter.Core
     {
         /// <summary>
         ///     Replaces any previous content rendered to this display with a
-        //      new displayable object.
+        ///     new displayable object.
         /// </summary>
         /// <param name="displayable">
         ///     The object to be displayed. Cannot be null.

--- a/src/ShellRouting/ShellRouter.cs
+++ b/src/ShellRouting/ShellRouter.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Jupyter.Core
     public class ShellRouter : IShellRouter
     {
         private readonly IDictionary<string, Action<Message>> shellHandlers = new Dictionary<string, Action<Message>>();
-        private Action<Message> fallback;
+        private Action<Message>? fallback;
         private readonly ILogger<ShellRouter> logger;
         private IServiceProvider services;
 
@@ -44,7 +44,7 @@ namespace Microsoft.Jupyter.Core
             (
                 shellHandlers.TryGetValue(message.Header.MessageType, out var handler)
                 ? handler : fallback
-            )(message);
+            )?.Invoke(message);
 
         public void RegisterHandler(string messageType, Action<Message> handler)
         {

--- a/src/Symbols/Magic.cs
+++ b/src/Symbols/Magic.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Jupyter.Core
     /// </summary>
     /// <remarks>
     ///      Each magic command method must have the signature
-    ///      <c>ExecuteResult (string, IChannel)</c>, similar to
+    ///      <c>ExecutionResult (string, IChannel)</c>, similar to
     ///      <ref>BaseEngine.ExecuteMundane</ref>.
     /// </remarks>
     [System.AttributeUsage(System.AttributeTargets.Method)]


### PR DESCRIPTION
This PR introduces a new method on `IChannel`, `DisplayUpdatable`, for writing updatable display data to the client. This new method returns an instance of the new `IUpdatableDisplay` interface, which callers can use to replace the content originally passed to `DisplayUpdatable`. This is especially useful for representing the status of long-running tasks, and is used in microsoft/iqsharp#94 to provide feedback to the user while packages are downloading:

![pkgs](https://user-images.githubusercontent.com/31516/74459452-2e4ea180-4e40-11ea-8914-84327b9531bc.gif)

This PR also adds a new `%tick` command to the echo kernel example demonstrating how to use the new updatable display mechanism:

![tick](https://user-images.githubusercontent.com/31516/74459490-40304480-4e40-11ea-9b28-ecf4b6bc5193.gif)
