### PR TITLE
Change shell execution methods to be async.

### DIFF
--- a/ci/ci.yml
+++ b/ci/ci.yml
@@ -6,7 +6,7 @@ resources:
   - repository: self
 variables:
   Build.Major: 1
-  Build.Minor: 2
+  Build.Minor: 3
   Build.Patch: $(Build.BuildId)
   Build.Configuration: 'Release'
   VersioningScheme: 'byPrereleaseNumber'

--- a/ci/signed.yml
+++ b/ci/signed.yml
@@ -6,7 +6,7 @@ resources:
   - repository: self
 variables:
   Build.Major: 1
-  Build.Minor: 2
+  Build.Minor: 3
   Build.Patch: $(Build.BuildId)
   Build.Configuration: 'Release'
   Assembly.Constants: 'SIGNED'

--- a/examples/echo-kernel/Echo Kernel.ipynb
+++ b/examples/echo-kernel/Echo Kernel.ipynb
@@ -143,7 +143,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "iecho",
+   "display_name": "IEcho",
    "language": "Echo",
    "name": "iecho"
   },

--- a/examples/echo-kernel/EchoEngine.cs
+++ b/examples/echo-kernel/EchoEngine.cs
@@ -18,8 +18,9 @@ namespace Microsoft.Jupyter.Core
             IShellServer shell,
             IShellRouter router,
             IOptions<KernelContext> context,
-            ILogger<EchoEngine> logger
-        ) : base(shell, router, context, logger) { }
+            ILogger<EchoEngine> logger,
+            IServiceProvider serviceProvider
+        ) : base(shell, router, context, logger, serviceProvider) { }
 
         public override async Task<ExecutionResult> ExecuteMundane(string input, IChannel channel) =>
             (Program.ShoutOption.HasValue() ? input.ToUpper() : input).ToExecutionResult();

--- a/examples/echo-kernel/EchoEngine.cs
+++ b/examples/echo-kernel/EchoEngine.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Logging;
 using System.Threading;
+using System.Threading.Tasks;
 
 namespace Microsoft.Jupyter.Core
 {
@@ -15,18 +16,19 @@ namespace Microsoft.Jupyter.Core
     {
         public EchoEngine(
             IShellServer shell,
+            IShellRouter router,
             IOptions<KernelContext> context,
             ILogger<EchoEngine> logger
-        ) : base(shell, context, logger) { }
+        ) : base(shell, router, context, logger) { }
 
-        public override ExecutionResult ExecuteMundane(string input, IChannel channel) =>
+        public override async Task<ExecutionResult> ExecuteMundane(string input, IChannel channel) =>
             (Program.ShoutOption.HasValue() ? input.ToUpper() : input).ToExecutionResult();
 
         [MagicCommand(
             "%tick",
             "Writes some ticks to demonstrate updatable display data."
         )]
-        public ExecutionResult ExecuteTick(string code, IChannel channel)
+        public async Task<ExecutionResult> ExecuteTick(string code, IChannel channel)
         {
             var tickMessage = "Tick.";
             var updatable = channel.DisplayUpdatable(tickMessage);

--- a/examples/moon-kernel/MoonEngine.cs
+++ b/examples/moon-kernel/MoonEngine.cs
@@ -23,8 +23,9 @@ namespace Microsoft.Jupyter.Core
             IShellServer shell,
             IShellRouter router,
             IOptions<KernelContext> context,
-            ILogger<MoonEngine> logger
-        ) : base(shell, router, context, logger)
+            ILogger<MoonEngine> logger,
+            IServiceProvider serviceProvider
+        ) : base(shell, router, context, logger, serviceProvider)
         {
             RegisterJsonEncoder(
                 new DynValueConverter()

--- a/examples/moon-kernel/MoonEngine.cs
+++ b/examples/moon-kernel/MoonEngine.cs
@@ -9,6 +9,7 @@ using MoonSharp.Interpreter.REPL;
 using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
+using System.Threading.Tasks;
 
 namespace Microsoft.Jupyter.Core
 {
@@ -20,9 +21,10 @@ namespace Microsoft.Jupyter.Core
 
         public MoonEngine(
             IShellServer shell,
+            IShellRouter router,
             IOptions<KernelContext> context,
             ILogger<MoonEngine> logger
-        ) : base(shell, context, logger)
+        ) : base(shell, router, context, logger)
         {
             RegisterJsonEncoder(
                 new DynValueConverter()
@@ -45,7 +47,7 @@ namespace Microsoft.Jupyter.Core
             interp = new ReplInterpreter(script);
         }
 
-        public override ExecutionResult ExecuteMundane(string input, IChannel channel)
+        public override async Task<ExecutionResult> ExecuteMundane(string input, IChannel channel)
         {
             var oldAction = printFn;
             printFn = channel.Stdout;

--- a/src/Data/Protocol.cs
+++ b/src/Data/Protocol.cs
@@ -176,7 +176,7 @@ namespace Microsoft.Jupyter.Core.Protocol
         public ExecuteStatus ExecuteStatus { get; set; }
 
         [JsonProperty("execution_count")]
-        public int ExecutionCount { get; set; }
+        public int? ExecutionCount { get; set; }
 
         // Don't use this! It's deprecated at the protocol level.
         [JsonProperty("payload")]

--- a/src/Engines/BaseEngine.cs
+++ b/src/Engines/BaseEngine.cs
@@ -131,17 +131,9 @@ namespace Microsoft.Jupyter.Core
             public TimeSpan Duration { get; }
         }
 
-        /// <summary>
-        ///      The number of cells that have been executed since the start of
-        ///      this engine. Used by clients to typeset cell numbers, e.g.:
-        ///      <c>In[12]:</c>.
-        /// </summary>
-        public int ExecutionCount { get; protected set; }
         protected List<string> History;
         private Dictionary<string, Stack<IResultEncoder>> serializers = new Dictionary<string, Stack<IResultEncoder>>();
         private List<ISymbolResolver> resolvers = new List<ISymbolResolver>();
-
-        private readonly Stack<Lazy<Task<ExecutionResult?>>> executionQueue = new Stack<Lazy<Task<ExecutionResult?>>>();
 
         /// <summary>
         /// This event is triggered when a non-magic cell is executed.
@@ -181,6 +173,8 @@ namespace Microsoft.Jupyter.Core
         /// </summary>
         public ILogger Logger { get; }
 
+        private IServiceProvider serviceProvider;
+
         /// <summary>
         ///      Constructs an engine that communicates with a given server,
         ///      and uses a given kernel context.
@@ -193,10 +187,10 @@ namespace Microsoft.Jupyter.Core
                 IShellServer shell,
                 IShellRouter router,
                 IOptions<KernelContext> context,
-                ILogger logger
+                ILogger logger,
+                IServiceProvider serviceProvider
         )
         {
-            ExecutionCount = 0;
             this.ShellServer = shell;
             this.ShellRouter = router;
             this.Context = context.Value;
@@ -408,7 +402,7 @@ namespace Microsoft.Jupyter.Core
             this.ShellServer.KernelInfoRequest += OnKernelInfoRequest;
             this.ShellServer.ShutdownRequest += OnShutdownRequest;
             
-            this.ShellRouter.RegisterHandler("execute_request", OnExecuteRequest);
+            this.ShellRouter.RegisterHandler<ExecuteRequestHandler>(serviceProvider);
         }
 
         #endregion
@@ -446,193 +440,6 @@ namespace Microsoft.Jupyter.Core
             {
                 this.Logger?.LogError(e, "Unable to process KernelInfoRequest");
             }
-        }
-
-        protected async virtual Task<ExecutionResult> ExecutionTaskForMessage(Message message, int executionCount)
-        {
-            var engineResponse = await Execute(
-                ((ExecuteRequestContent)message.Content).Code,
-                new ExecutionChannel(this, message)
-            );
-
-            
-            // Send the engine's output as an execution result.
-            if (engineResponse.Output != null)
-            {
-                var serialized = EncodeForDisplay(engineResponse.Output);
-                this.ShellServer.SendIoPubMessage(
-                    new Message
-                    {
-                        ZmqIdentities = message.ZmqIdentities,
-                        ParentHeader = message.Header,
-                        Metadata = null,
-                        Content = new ExecuteResultContent
-                        {
-                            ExecutionCount = executionCount,
-                            Data = serialized.Data,
-                            Metadata = serialized.Metadata
-                        },
-                        Header = new MessageHeader
-                        {
-                            MessageType = "execute_result"
-                        }
-                    }
-                );
-            }
-
-            // Handle the message.
-            this.ShellServer.SendShellMessage(
-                new Message
-                {
-                    ZmqIdentities = message.ZmqIdentities,
-                    ParentHeader = message.Header,
-                    Metadata = null,
-                    Content = new ExecuteReplyContent
-                    {
-                        ExecuteStatus = engineResponse.Status,
-                        ExecutionCount = executionCount
-                    },
-                    Header = new MessageHeader
-                    {
-                        MessageType = "execute_reply"
-                    }
-                }
-            );
-
-            return engineResponse;
-        }
-
-        protected async Task<bool> AwaitPreviousTask(Task<ExecutionResult?> previousTask, Message message)
-        {
-            var previousResult = await previousTask;
-            if (previousResult == null || previousResult.Value.Status != ExecuteStatus.Ok)
-            {
-                // The previous call failed, so abort here and let the
-                // shell server know.
-                this.ShellServer.SendShellMessage(
-                    new Message
-                    {
-                        ZmqIdentities = message.ZmqIdentities,
-                        ParentHeader = message.Header,
-                        Metadata = null,
-                        Content = new ExecuteReplyContent
-                        {
-                            ExecuteStatus = ExecuteStatus.Abort,
-                            ExecutionCount = null
-                        },
-                        Header = new MessageHeader
-                        {
-                            MessageType = "execute_reply"
-                        }
-                    }
-                );
-
-                // Finish by telling the client that we're free again.
-                this.ShellServer.SendIoPubMessage(
-                    new Message
-                    {
-                        Header = new MessageHeader
-                        {
-                            MessageType = "status"
-                        },
-                        Content = new KernelStatusContent
-                        {
-                            ExecutionState = ExecutionState.Idle
-                        }
-                    }.AsReplyTo(message)
-                );
-                return false;
-            }
-            else return true;
-        }
-
-        private void NotifyBusyStatus(Message message, ExecutionState state)
-        {
-            // Begin by sending that we're busy.
-            this.ShellServer.SendIoPubMessage(
-                new Message
-                {
-                    Header = new MessageHeader
-                    {
-                        MessageType = "status"
-                    },
-                    Content = new KernelStatusContent
-                    {
-                        ExecutionState = state
-                    }
-                }.AsReplyTo(message)
-            );
-        }
-
-        private int IncrementExecutionCount()
-        {
-            lock (this)
-            {
-                return ++this.ExecutionCount;
-            }
-        }
-
-        public virtual Task OnExecuteRequest(Message message)
-        {
-
-            // If there's nothing in the execution queue, then we execute and
-            // add that task to the queue.
-            // Otherwise, we add a new task that waits for the previous task
-            // and aborts if it fails.
-                this.Logger.LogDebug($"Asked to execute code:\n{((ExecuteRequestContent)message.Content).Code}");
-                Task<ExecutionResult?>? previousTask;
-                Lazy<Task<ExecutionResult?>>? currentExecutionTask = null;
-                
-                async Task<ExecutionResult?> ExecuteCurrent()
-                {
-                    int? executionCount = null;
-                
-                    if (previousTask != null)
-                    {
-                        if (!await AwaitPreviousTask(previousTask, message))
-                        {
-                            return null;
-                        }
-                        executionCount = IncrementExecutionCount();
-                    }
-                    else
-                    {
-                        executionCount = IncrementExecutionCount();
-                        NotifyBusyStatus(message, ExecutionState.Busy);
-                    }
-
-                    
-                    try
-                    {
-                        var result = await ExecutionTaskForMessage(message, executionCount.Value);
-                        lock (executionQueue)
-                        {
-                            executionQueue.Pop();
-                        }
-                        return result;
-                    }
-                    catch (Exception e)
-                    {
-                        this.Logger?.LogError(e, "Unable to process ExecuteRequest");
-                        return new ExecutionResult
-                        {
-                            Output = e,
-                            Status = ExecuteStatus.Error
-                        };
-                    }
-                }
-                
-                // The very first thing we need to do is lock the queue
-                // and check if another cell is running.
-                lock (executionQueue)
-                {
-                    previousTask = (executionQueue.Count > 0
-                                    ? executionQueue.Peek()
-                                    : null)?.Value;
-                    currentExecutionTask = new Lazy<Task<ExecutionResult?>>(ExecuteCurrent);
-                    executionQueue.Push(currentExecutionTask);
-                }
-                return currentExecutionTask.Value;
         }
 
         public virtual void OnShutdownRequest(Message message)

--- a/src/Engines/BaseEngine.cs
+++ b/src/Engines/BaseEngine.cs
@@ -11,6 +11,8 @@ using Microsoft.Extensions.Options;
 using Newtonsoft.Json;
 using Microsoft.Jupyter.Core.Protocol;
 using System.Diagnostics;
+using System.Threading.Tasks;
+using System.Threading;
 
 namespace Microsoft.Jupyter.Core
 {
@@ -139,6 +141,8 @@ namespace Microsoft.Jupyter.Core
         private Dictionary<string, Stack<IResultEncoder>> serializers = new Dictionary<string, Stack<IResultEncoder>>();
         private List<ISymbolResolver> resolvers = new List<ISymbolResolver>();
 
+        private Task<ExecutionResult>? currentExecutionTask = null;
+
         /// <summary>
         /// This event is triggered when a non-magic cell is executed.
         /// </summary>
@@ -161,6 +165,8 @@ namespace Microsoft.Jupyter.Core
         ///     shell IOPub socket.
         /// </summary>
         public IShellServer ShellServer { get; }
+
+        public IShellRouter ShellRouter { get; }
 
         /// <summary>
         ///      The context object for this engine, recording how the kernel
@@ -185,12 +191,14 @@ namespace Microsoft.Jupyter.Core
         /// </remarks>
         public BaseEngine(
                 IShellServer shell,
+                IShellRouter router,
                 IOptions<KernelContext> context,
                 ILogger logger
         )
         {
             ExecutionCount = 0;
             this.ShellServer = shell;
+            this.ShellRouter = router;
             this.Context = context.Value;
             this.Logger = logger;
 
@@ -398,8 +406,9 @@ namespace Microsoft.Jupyter.Core
         public virtual void Start()
         {
             this.ShellServer.KernelInfoRequest += OnKernelInfoRequest;
-            this.ShellServer.ExecuteRequest += OnExecuteRequest;
             this.ShellServer.ShutdownRequest += OnShutdownRequest;
+            
+            this.ShellRouter.RegisterHandler("execute_request", OnExecuteRequest);
         }
 
         #endregion
@@ -439,7 +448,7 @@ namespace Microsoft.Jupyter.Core
             }
         }
 
-        public virtual void OnExecuteRequest(Message message)
+        public async virtual Task OnExecuteRequest(Message message)
         {
             this.Logger.LogDebug($"Asked to execute code:\n{((ExecuteRequestContent)message.Content).Code}");
 
@@ -460,11 +469,71 @@ namespace Microsoft.Jupyter.Core
                     }.AsReplyTo(message)
                 );
 
+                Task<ExecutionResult>? previousTask;
+                lock (this)
+                {
+                    previousTask = currentExecutionTask;
+                }
+                // Check if another cell is running.
+                if (previousTask != null)
+                {
+                    Logger.LogDebug("A previous cell is still running, waiting...");
+                    var previousResult = await previousTask;
+                    if (previousResult.Status != ExecuteStatus.Ok)
+                    {
+                        // The previous call failed, so abort here and let the
+                        // shell server know.
+                        this.ShellServer.SendShellMessage(
+                            new Message
+                            {
+                                ZmqIdentities = message.ZmqIdentities,
+                                ParentHeader = message.Header,
+                                Metadata = null,
+                                Content = new ExecuteReplyContent
+                                {
+                                    ExecuteStatus = ExecuteStatus.Abort,
+                                    ExecutionCount = this.ExecutionCount
+                                },
+                                Header = new MessageHeader
+                                {
+                                    MessageType = "execute_reply"
+                                }
+                            }
+                        );
+
+                        // Finish by telling the client that we're free again.
+                        this.ShellServer.SendIoPubMessage(
+                            new Message
+                            {
+                                Header = new MessageHeader
+                                {
+                                    MessageType = "status"
+                                },
+                                Content = new KernelStatusContent
+                                {
+                                    ExecutionState = ExecutionState.Idle
+                                }
+                            }.AsReplyTo(message)
+                        );
+                        return;
+                    }
+                }
+
                 // Run in the engine.
-                var engineResponse = Execute(
-                    ((ExecuteRequestContent)message.Content).Code,
-                    new ExecutionChannel(this, message)
-                );
+                int? executionCount = null;
+                lock (this)
+                {
+                    executionCount = ++this.ExecutionCount;
+                    currentExecutionTask = Execute(
+                        ((ExecuteRequestContent)message.Content).Code,
+                        new ExecutionChannel(this, message)
+                    );
+                }
+                var engineResponse = await currentExecutionTask!;
+                lock (this)
+                {
+                    currentExecutionTask = null;
+                }
 
                 // Send the engine's output as an execution result.
                 if (engineResponse.Output != null)
@@ -478,7 +547,7 @@ namespace Microsoft.Jupyter.Core
                             Metadata = null,
                             Content = new ExecuteResultContent
                             {
-                                ExecutionCount = this.ExecutionCount,
+                                ExecutionCount = executionCount.Value,
                                 Data = serialized.Data,
                                 Metadata = serialized.Metadata
                             },
@@ -500,28 +569,13 @@ namespace Microsoft.Jupyter.Core
                         Content = new ExecuteReplyContent
                         {
                             ExecuteStatus = engineResponse.Status,
-                            ExecutionCount = this.ExecutionCount
+                            ExecutionCount = executionCount.Value
                         },
                         Header = new MessageHeader
                         {
                             MessageType = "execute_reply"
                         }
                     }
-                );
-
-                // Finish by telling the client that we're free again.
-                this.ShellServer.SendIoPubMessage(
-                    new Message
-                    {
-                        Header = new MessageHeader
-                        {
-                            MessageType = "status"
-                        },
-                        Content = new KernelStatusContent
-                        {
-                            ExecutionState = ExecutionState.Idle
-                        }
-                    }.AsReplyTo(message)
                 );
             }
             catch (Exception e)
@@ -602,28 +656,25 @@ namespace Microsoft.Jupyter.Core
         /// <param name="input">the cell's content.</param>
         /// <param name="channel">the channel to generate messages or errors.</param>
         /// <returns>An <c>ExecutionResult</c> instance with the results of </returns>
-        public virtual ExecutionResult Execute(string input, IChannel channel)
+        public async virtual Task<ExecutionResult> Execute(string input, IChannel channel)
         {
-            this.ExecutionCount++;
-
             try
             {
                 this.History.Add(input);
 
                 // We first check to see if the first token is a
                 // magic command for this kernel.
-
                 if (IsHelp(input, out var helpSymbol))
                 {
-                    return ExecuteAndNotify(input, helpSymbol, channel, ExecuteHelp, HelpExecuted);
+                    return await ExecuteAndNotify(input, helpSymbol, channel, ExecuteHelp, HelpExecuted);
                 }
                 else if (IsMagic(input, out var magicSymbol))
                 {
-                    return ExecuteAndNotify(input, magicSymbol, channel, ExecuteMagic, MagicExecuted);
+                    return await ExecuteAndNotify(input, magicSymbol, channel, ExecuteMagic, MagicExecuted);
                 }
                 else
                 {
-                    return ExecuteAndNotify(input, channel, ExecuteMundane, MundaneExecuted);
+                    return await ExecuteAndNotify(input, channel, ExecuteMundane, MundaneExecuted);
                 }
             }
             catch (Exception e)
@@ -634,7 +685,7 @@ namespace Microsoft.Jupyter.Core
             }
         }
 
-        public virtual ExecutionResult ExecuteHelp(string input, ISymbol symbol, IChannel channel)
+        public virtual async Task<ExecutionResult> ExecuteHelp(string input, ISymbol symbol, IChannel channel)
         {
             if (symbol == null)
             {
@@ -647,7 +698,7 @@ namespace Microsoft.Jupyter.Core
             }
         }
 
-        public virtual ExecutionResult ExecuteMagic(string input, ISymbol symbol, IChannel channel)
+        public virtual async Task<ExecutionResult> ExecuteMagic(string input, ISymbol symbol, IChannel channel)
         {
             // We should never be called with an ISymbol that isn't a MagicSymbol,
             // since this method should only be called by using magicResolver.
@@ -658,7 +709,7 @@ namespace Microsoft.Jupyter.Core
             {
                 var parts = input.Trim().Split(new[] { ' ' }, 2);
                 var remainingInput = parts.Length > 1 ? parts[1] : "";
-                return magic.Execute(remainingInput, channel);
+                return await magic.Execute(remainingInput, channel);
             }
             else
             {
@@ -679,15 +730,15 @@ namespace Microsoft.Jupyter.Core
         ///     as the result of executing the input (e.g.: as the result typeset
         ///     as <c>Out[12]:</c> outputs).
         /// </returns>
-        public abstract ExecutionResult ExecuteMundane(string input, IChannel channel);
+        public abstract Task<ExecutionResult> ExecuteMundane(string input, IChannel channel);
 
         /// <summary>
         ///     Executes the given action with the corresponding parameters, and then triggers the given event.
         /// </summary>
-        public ExecutionResult ExecuteAndNotify(string input, IChannel channel, Func<string, IChannel, ExecutionResult> action, EventHandler<ExecutedEventArgs> evt)
+        public async Task<ExecutionResult> ExecuteAndNotify(string input, IChannel channel, Func<string, IChannel, Task<ExecutionResult>> action, EventHandler<ExecutedEventArgs> evt)
         {
             var duration = Stopwatch.StartNew();
-            var result = action(input, channel);
+            var result = await action(input, channel);
             duration.Stop();
 
             evt?.Invoke(this, new ExecutedEventArgs(null, result, duration.Elapsed));
@@ -697,10 +748,16 @@ namespace Microsoft.Jupyter.Core
         /// <summary>
         ///     Executes the given action with the corresponding parameters, and then triggers the given event.
         /// </summary>
-        public ExecutionResult ExecuteAndNotify(string input, ISymbol symbol, IChannel channel, Func<string, ISymbol, IChannel, ExecutionResult> action, EventHandler<ExecutedEventArgs> evt)
+        public async Task<ExecutionResult> ExecuteAndNotify(
+            string input,
+            ISymbol symbol,
+            IChannel channel,
+            Func<string, ISymbol, IChannel, Task<ExecutionResult>> action,
+            EventHandler<ExecutedEventArgs> evt
+        )
         {
             var duration = Stopwatch.StartNew();
-            var result = action(input, symbol, channel);
+            var result = await action(input, symbol, channel);
             duration.Stop();
 
             evt?.Invoke(this, new ExecutedEventArgs(symbol, result, duration.Elapsed));

--- a/src/Engines/ExecuteRequestHandler.cs
+++ b/src/Engines/ExecuteRequestHandler.cs
@@ -171,6 +171,7 @@ namespace Microsoft.Jupyter.Core
 
             if (previousResult != null && previousResult.Value.Status != ExecuteStatus.Ok)
             {
+                this.logger.LogDebug("Aborting due to previous execution result indicating failure: {PreviousResult}", previousResult.Value);
                 await SendAbortMessage(message);
                 return ExecutionResult.Aborted;
             }

--- a/src/Engines/ExecuteRequestHandler.cs
+++ b/src/Engines/ExecuteRequestHandler.cs
@@ -1,0 +1,193 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Reflection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Newtonsoft.Json;
+using Microsoft.Jupyter.Core.Protocol;
+using System.Diagnostics;
+using System.Threading.Tasks;
+using System.Threading;
+
+namespace Microsoft.Jupyter.Core
+{
+    internal class ExecuteRequestHandler : OrderedShellHandler<ExecutionResult>
+    {
+
+        private IExecutionEngine engine;
+        private IShellServer shellServer;
+
+        private Task<bool>? previousTask = null;
+
+        /// <summary>
+        ///      The number of cells that have been executed since the start of
+        ///      this engine. Used by clients to typeset cell numbers, e.g.:
+        ///      <c>In[12]:</c>.
+        /// </summary>
+        public int ExecutionCount { get; protected set; } = 0;
+
+        public ExecuteRequestHandler(IExecutionEngine engine, IShellServer server)
+        {
+            this.engine = engine;
+            this.shellServer = shellServer;
+        }
+
+        public string MessageType => "execute_request";
+        
+        protected async virtual Task<ExecutionResult> ExecutionTaskForMessage(Message message, int executionCount)
+        {
+            var engineResponse = await Execute(
+                ((ExecuteRequestContent)message.Content).Code,
+                new ExecutionChannel(this, message)
+            );
+
+            
+            // Send the engine's output as an execution result.
+            if (engineResponse.Output != null)
+            {
+                var serialized = EncodeForDisplay(engineResponse.Output);
+                this.shellServer.SendIoPubMessage(
+                    new Message
+                    {
+                        ZmqIdentities = message.ZmqIdentities,
+                        ParentHeader = message.Header,
+                        Metadata = null,
+                        Content = new ExecuteResultContent
+                        {
+                            ExecutionCount = executionCount,
+                            Data = serialized.Data,
+                            Metadata = serialized.Metadata
+                        },
+                        Header = new MessageHeader
+                        {
+                            MessageType = "execute_result"
+                        }
+                    }
+                );
+            }
+
+            // Handle the message.
+            this.shellServer.SendShellMessage(
+                new Message
+                {
+                    ZmqIdentities = message.ZmqIdentities,
+                    ParentHeader = message.Header,
+                    Metadata = null,
+                    Content = new ExecuteReplyContent
+                    {
+                        ExecuteStatus = engineResponse.Status,
+                        ExecutionCount = executionCount
+                    },
+                    Header = new MessageHeader
+                    {
+                        MessageType = "execute_reply"
+                    }
+                }
+            );
+
+            return engineResponse;
+        }
+
+        protected async Task SendAbortMessage(Message message)
+        {
+            // The previous call failed, so abort here and let the
+            // shell server know.
+            this.shellServer.SendShellMessage(
+                new Message
+                {
+                    ZmqIdentities = message.ZmqIdentities,
+                    ParentHeader = message.Header,
+                    Metadata = null,
+                    Content = new ExecuteReplyContent
+                    {
+                        ExecuteStatus = ExecuteStatus.Abort,
+                        ExecutionCount = null
+                    },
+                    Header = new MessageHeader
+                    {
+                        MessageType = "execute_reply"
+                    }
+                }
+            );
+
+            // Finish by telling the client that we're free again.
+            this.shellServer.SendIoPubMessage(
+                new Message
+                {
+                    Header = new MessageHeader
+                    {
+                        MessageType = "status"
+                    },
+                    Content = new KernelStatusContent
+                    {
+                        ExecutionState = ExecutionState.Idle
+                    }
+                }.AsReplyTo(message)
+            );
+        }
+
+        private void NotifyBusyStatus(Message message, ExecutionState state)
+        {
+            // Begin by sending that we're busy.
+            this.shellServer.SendIoPubMessage(
+                new Message
+                {
+                    Header = new MessageHeader
+                    {
+                        MessageType = "status"
+                    },
+                    Content = new KernelStatusContent
+                    {
+                        ExecutionState = state
+                    }
+                }.AsReplyTo(message)
+            );
+        }
+
+        private int IncrementExecutionCount()
+        {
+            lock (this)
+            {
+                return ++this.ExecutionCount;
+            }
+        }
+
+        public override async Task<ExecutionResult> HandleAsync(Message message, ExecutionResult? previousResult)
+        {
+            this.Logger.LogDebug($"Asked to execute code:\n{((ExecuteRequestContent)message.Content).Code}");
+
+            if (previousResult != null && previousResult.ExecuteStatus != ExecuteStatus.Ok)
+            {
+                SendAbortMessage(message);
+                return ExecutionResult.Aborted;
+            }
+            
+            executionCount = IncrementExecutionCount();
+            NotifyBusyStatus(message, ExecutionState.Busy);
+
+            try
+            {
+                var result = await ExecutionTaskForMessage(message, executionCount.Value);
+                return result;
+            }
+            catch (Exception e)
+            {
+                this.Logger?.LogError(e, "Unable to process ExecuteRequest");
+                return new ExecutionResult
+                {
+                    Output = e,
+                    Status = ExecuteStatus.Error
+                };
+            }
+        }
+
+    }
+
+}

--- a/src/Engines/ExecuteRequestHandler.cs
+++ b/src/Engines/ExecuteRequestHandler.cs
@@ -15,16 +15,20 @@ using Microsoft.Jupyter.Core.Protocol;
 using System.Diagnostics;
 using System.Threading.Tasks;
 using System.Threading;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Microsoft.Jupyter.Core
 {
     internal class ExecuteRequestHandler : OrderedShellHandler<ExecutionResult>
     {
 
-        private IExecutionEngine engine;
+        private BaseEngine engine;
         private IShellServer shellServer;
 
         private Task<bool>? previousTask = null;
+        private ILogger<ExecuteRequestHandler>? logger = null;
+
+        protected override ILogger? Logger => logger;
 
         /// <summary>
         ///      The number of cells that have been executed since the start of
@@ -33,26 +37,28 @@ namespace Microsoft.Jupyter.Core
         /// </summary>
         public int ExecutionCount { get; protected set; } = 0;
 
-        public ExecuteRequestHandler(IExecutionEngine engine, IShellServer server)
+        public ExecuteRequestHandler(BaseEngine engine, IServiceProvider serviceProvider)
         {
+            if (serviceProvider == null) { throw new ArgumentNullException(nameof(serviceProvider)); }
             this.engine = engine;
-            this.shellServer = shellServer;
+            this.shellServer = serviceProvider.GetService<IShellServer>();
+            this.logger = serviceProvider.GetService<ILogger<ExecuteRequestHandler>>();
         }
 
-        public string MessageType => "execute_request";
+        public override string MessageType => "execute_request";
         
         protected async virtual Task<ExecutionResult> ExecutionTaskForMessage(Message message, int executionCount)
         {
-            var engineResponse = await Execute(
+            var engineResponse = await engine.Execute(
                 ((ExecuteRequestContent)message.Content).Code,
-                new ExecutionChannel(this, message)
+                new BaseEngine.ExecutionChannel(engine, message)
             );
 
             
             // Send the engine's output as an execution result.
             if (engineResponse.Output != null)
             {
-                var serialized = EncodeForDisplay(engineResponse.Output);
+                var serialized = engine.EncodeForDisplay(engineResponse.Output);
                 this.shellServer.SendIoPubMessage(
                     new Message
                     {
@@ -161,30 +167,34 @@ namespace Microsoft.Jupyter.Core
 
         public override async Task<ExecutionResult> HandleAsync(Message message, ExecutionResult? previousResult)
         {
-            this.Logger.LogDebug($"Asked to execute code:\n{((ExecuteRequestContent)message.Content).Code}");
+            this.logger.LogDebug($"Asked to execute code:\n{((ExecuteRequestContent)message.Content).Code}");
 
-            if (previousResult != null && previousResult.ExecuteStatus != ExecuteStatus.Ok)
+            if (previousResult != null && previousResult.Value.Status != ExecuteStatus.Ok)
             {
-                SendAbortMessage(message);
+                await SendAbortMessage(message);
                 return ExecutionResult.Aborted;
             }
             
-            executionCount = IncrementExecutionCount();
+            var executionCount = IncrementExecutionCount();
             NotifyBusyStatus(message, ExecutionState.Busy);
 
             try
             {
-                var result = await ExecutionTaskForMessage(message, executionCount.Value);
+                var result = await ExecutionTaskForMessage(message, executionCount);
                 return result;
             }
             catch (Exception e)
             {
-                this.Logger?.LogError(e, "Unable to process ExecuteRequest");
+                this.logger?.LogError(e, "Unable to process ExecuteRequest");
                 return new ExecutionResult
                 {
                     Output = e,
                     Status = ExecuteStatus.Error
                 };
+            }
+            finally
+            {
+                NotifyBusyStatus(message, ExecutionState.Idle);
             }
         }
 

--- a/src/Engines/ExecutionResult.cs
+++ b/src/Engines/ExecutionResult.cs
@@ -16,6 +16,18 @@ namespace Microsoft.Jupyter.Core
     {
         public ExecuteStatus Status;
         public object Output;
+
+        public static ExecutionResult Failed => new ExecutionResult
+        {
+            Status = ExecuteStatus.Error,
+            Output = null
+        };
+
+        public static ExecutionResult Aborted => new ExecutionResult
+        {
+            Status = ExecuteStatus.Abort,
+            Output = null
+        };
     }
 
 }

--- a/src/KernelApplication.cs
+++ b/src/KernelApplication.cs
@@ -612,8 +612,12 @@ namespace Microsoft.Jupyter.Core
 
             // Minimally, we need to start a server for each of the heartbeat,
             // control and shell sockets.
+            var scope = logger.BeginScope("Starting kernel services");
+            logger.LogDebug("Getting heartbeat service.");
             var heartbeatServer = serviceProvider.GetService<IHeartbeatServer>();
+            logger.LogDebug("Getting shell service.");
             var shellServer = serviceProvider.GetService<IShellServer>();
+            logger.LogDebug("Getting engine service.");
             var engine = serviceProvider.GetService<IExecutionEngine>();
 
             shellServer.ShutdownRequest += OnShutdownRequest;
@@ -621,9 +625,14 @@ namespace Microsoft.Jupyter.Core
             // We start by launching a heartbeat server, which echoes whatever
             // input it gets from the client. Clients can use this to ensure
             // that the kernel is still alive and responsive.
+            logger.LogDebug("Starting engine service.");
             engine.Start();
+            logger.LogDebug("Starting heartbeat service.");
             heartbeatServer.Start();
+            logger.LogDebug("Starting shell service.");
             shellServer.Start();
+
+            scope.Dispose();
 
             KernelStarted?.Invoke(serviceProvider);
 

--- a/src/Servers/IShellServer.cs
+++ b/src/Servers/IShellServer.cs
@@ -9,8 +9,6 @@ namespace Microsoft.Jupyter.Core
     {
         event Action<Message> KernelInfoRequest;
 
-        event Action<Message> ExecuteRequest;
-
         event Action<Message> ShutdownRequest;
 
         void SendShellMessage(Message message);

--- a/src/Servers/ShellServer.cs
+++ b/src/Servers/ShellServer.cs
@@ -136,18 +136,11 @@ namespace Microsoft.Jupyter.Core
 
                     // If this is our first message, we need to set the session
                     // id.
-                    if (session == null)
-                    {
-                        session = nextMessage.Header.Session;
-                    }
+                    session ??= nextMessage.Header.Session;
 
                     // Get a service that can handle the message type and
                     // dispatch.
-                    var task = router.Handle(nextMessage);
-
-                    // If the handler requires additional processing, delegate
-                    // that to a background thread.
-                    if (task != null) Task.Run(() => task);
+                    router.Handle(nextMessage);
                 }
                 catch (ProtocolViolationException ex)
                 {

--- a/src/Servers/ShellServer.cs
+++ b/src/Servers/ShellServer.cs
@@ -143,7 +143,11 @@ namespace Microsoft.Jupyter.Core
 
                     // Get a service that can handle the message type and
                     // dispatch.
-                    Task.Run(() => router.HandleAsync(nextMessage));
+                    var task = router.Handle(nextMessage);
+
+                    // If the handler requires additional processing, delegate
+                    // that to a background thread.
+                    if (task != null) Task.Run(() => task);
                 }
                 catch (ProtocolViolationException ex)
                 {

--- a/src/ShellRouting/IShellHandler.cs
+++ b/src/ShellRouting/IShellHandler.cs
@@ -1,0 +1,36 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#nullable enable
+
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Jupyter.Core.Protocol;
+
+namespace Microsoft.Jupyter.Core
+{
+    /// <summary>
+    ///     Represents a class that can handle and respond to
+    ///     shell messages coming in from a client.
+    /// </summary>
+    public interface IShellHandler
+    {
+        /// <summary>
+        ///     The message type handled by this handler (e.g.: <c>kernel_info_request</c>).
+        /// </summary>
+        public string MessageType { get; }
+
+        /// <summary>
+        ///     Called by the shell server to asynchronously handle a message
+        ///     coming in from the client. Either returns <c>null</c> if no
+        ///     further handling is required, or a task that can be awaited on
+        ///     for the message to be completely handled.
+        /// </summary>
+        /// <param name="message">
+        ///     The incoming message to be handled.
+        /// </param>
+        public Task HandleAsync(Message message);
+    }
+}

--- a/src/ShellRouting/IShellRouter.cs
+++ b/src/ShellRouting/IShellRouter.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+#nullable enable
+
 using System;
 using System.Linq;
 using System.Threading.Tasks;
@@ -19,24 +21,17 @@ namespace Microsoft.Jupyter.Core
         ///     The message type handled by this handler (e.g.: <c>kernel_info_request</c>).
         /// </summary>
         public string MessageType { get; }
-        
-        /// <summary>
-        ///     Called by the shell server to handle a message coming in from the client.
-        /// </summary>
-        /// <param name="message">
-        ///     The incoming message to be handled.
-        /// </param>
-        public void Handle(Message message);
 
         /// <summary>
         ///     Called by the shell server to asynchronously handle a message
-        ///     coming in from the client.
+        ///     coming in from the client. Either returns <c>null</c> if no
+        ///     further handling is required, or a task that can be awaited on
+        ///     for the message to be completely handled.
         /// </summary>
         /// <param name="message">
         ///     The incoming message to be handled.
         /// </param>
-        public async Task HandleAsync(Message message) =>
-            await Task.Run(() => Handle(message));
+        public Task? BeginHandlingMessage(Message message);
     }
 
     /// <summary>
@@ -45,43 +40,12 @@ namespace Microsoft.Jupyter.Core
     /// </summary>
     public interface IShellRouter
     {
+
         /// <summary>
         ///     Registers an action that can be used to handle a
-        ///     particular message type.
-        /// </summary>
-        /// <param name="messageType">
-        ///     The type of message to be handled.
-        /// </param>
-        /// <param name="handler">
-        ///     An action that can be used to handle incoming messages of
-        ///     type <c>messageType</c>.
-        /// </param>
-        /// <example>
-        ///     To register a handler that logs <c>ping_request</c>
-        ///     message IDs:
-        ///     <code><![CDATA[
-        ///         router.RegisterHandler(
-        ///             "ping_request"
-        ///             message => logger.LogDebug(
-        ///                 "Got ping_request with id {Id}.",
-        ///                 message.Header.Id
-        ///             )
-        ///         );
-        ///     ]]></code>
-        /// </example>
-        public void RegisterHandler(string messageType, Action<Message> handler)
-        {
-            RegisterHandler(
-                messageType,
-                async message =>
-                    await Task.Run(() => handler(message))
-            );
-        }
-
-        
-        /// <summary>
-        ///     Registers an action that can be used to asynchronously handle a
-        ///     particular message type.
+        ///     particular message type. This action either returns a task
+        ///     that can be awaited if further processing is required, or
+        ///     <c>null</c> if the handler has completed handling the message.
         /// </summary>
         /// <param name="messageType">
         ///     The type of message to be handled.
@@ -103,7 +67,7 @@ namespace Microsoft.Jupyter.Core
         ///         );
         ///     ]]></code>
         /// </example>
-        public void RegisterHandler(string messageType, Func<Message, Task> handler);
+        public void RegisterHandler(string messageType, Func<Message, Task?> handler);
 
         /// <summary>
         ///     Registers a handler that can be used to handle a
@@ -116,7 +80,7 @@ namespace Microsoft.Jupyter.Core
         ///     message type to be handled.
         /// </param>
         public void RegisterHandler(IShellHandler handler) =>
-            RegisterHandler(handler.MessageType, handler.HandleAsync);
+            RegisterHandler(handler.MessageType, handler.BeginHandlingMessage);
 
         /// <summary>
         ///     Registers an action to be used to handle messages
@@ -126,7 +90,7 @@ namespace Microsoft.Jupyter.Core
         ///     An action that can be used to handle messages
         ///     whose message types do not have appropriate handlers.
         /// </param>
-        public void RegisterFallback(Func<Message, Task> fallback);
+        public void RegisterFallback(Func<Message, Task?> fallback);
 
         /// <summary>
         ///     Calls the appropriate handler for a given message,
@@ -136,7 +100,7 @@ namespace Microsoft.Jupyter.Core
         /// <param name="message">
         ///     The message to be handled.
         /// </param>
-        public Task HandleAsync(Message message);
+        public Task? Handle(Message message);
 
         /// <summary>
         ///     Searches an assembly for types representing shell

--- a/src/ShellRouting/IShellRouter.cs
+++ b/src/ShellRouting/IShellRouter.cs
@@ -12,29 +12,6 @@ using Microsoft.Jupyter.Core.Protocol;
 namespace Microsoft.Jupyter.Core
 {
     /// <summary>
-    ///     Represents a class that can handle and respond to
-    ///     shell messages coming in from a client.
-    /// </summary>
-    public interface IShellHandler
-    {
-        /// <summary>
-        ///     The message type handled by this handler (e.g.: <c>kernel_info_request</c>).
-        /// </summary>
-        public string MessageType { get; }
-
-        /// <summary>
-        ///     Called by the shell server to asynchronously handle a message
-        ///     coming in from the client. Either returns <c>null</c> if no
-        ///     further handling is required, or a task that can be awaited on
-        ///     for the message to be completely handled.
-        /// </summary>
-        /// <param name="message">
-        ///     The incoming message to be handled.
-        /// </param>
-        public Task? BeginHandlingMessage(Message message);
-    }
-
-    /// <summary>
     ///     Represents a class that can be used to route incoming shell
     ///     messages to appropriate handlers.
     /// </summary>
@@ -69,6 +46,11 @@ namespace Microsoft.Jupyter.Core
         /// </example>
         public void RegisterHandler(string messageType, Func<Message, Task?> handler);
 
+        public void RegisterHandler<THandler>(IServiceProvider serviceProvider) =>
+            RegisterHandler(
+                ActivatorUtilities.CreateInstance(serviceProvider, typeof(THandler))
+            );
+
         /// <summary>
         ///     Registers a handler that can be used to handle a
         ///     particular message type.
@@ -80,7 +62,7 @@ namespace Microsoft.Jupyter.Core
         ///     message type to be handled.
         /// </param>
         public void RegisterHandler(IShellHandler handler) =>
-            RegisterHandler(handler.MessageType, handler.BeginHandlingMessage);
+            RegisterHandler(handler.MessageType, handler.HandleAsync);
 
         /// <summary>
         ///     Registers an action to be used to handle messages

--- a/src/ShellRouting/IShellRouter.cs
+++ b/src/ShellRouting/IShellRouter.cs
@@ -48,7 +48,7 @@ namespace Microsoft.Jupyter.Core
 
         public void RegisterHandler<THandler>(IServiceProvider serviceProvider) =>
             RegisterHandler(
-                ActivatorUtilities.CreateInstance(serviceProvider, typeof(THandler))
+                (IShellHandler)ActivatorUtilities.CreateInstance(serviceProvider, typeof(THandler))
             );
 
         /// <summary>

--- a/src/ShellRouting/IShellRouter.cs
+++ b/src/ShellRouting/IShellRouter.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Linq;
+using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Jupyter.Core.Protocol;
 
@@ -26,6 +27,16 @@ namespace Microsoft.Jupyter.Core
         ///     The incoming message to be handled.
         /// </param>
         public void Handle(Message message);
+
+        /// <summary>
+        ///     Called by the shell server to asynchronously handle a message
+        ///     coming in from the client.
+        /// </summary>
+        /// <param name="message">
+        ///     The incoming message to be handled.
+        /// </param>
+        public async Task HandleAsync(Message message) =>
+            await Task.Run(() => Handle(message));
     }
 
     /// <summary>
@@ -58,7 +69,41 @@ namespace Microsoft.Jupyter.Core
         ///         );
         ///     ]]></code>
         /// </example>
-        public void RegisterHandler(string messageType, Action<Message> handler);
+        public void RegisterHandler(string messageType, Action<Message> handler)
+        {
+            RegisterHandler(
+                messageType,
+                async message =>
+                    await Task.Run(() => handler(message))
+            );
+        }
+
+        
+        /// <summary>
+        ///     Registers an action that can be used to asynchronously handle a
+        ///     particular message type.
+        /// </summary>
+        /// <param name="messageType">
+        ///     The type of message to be handled.
+        /// </param>
+        /// <param name="handler">
+        ///     An action that can be used to handle incoming messages of
+        ///     type <c>messageType</c>.
+        /// </param>
+        /// <example>
+        ///     To register a handler that logs <c>ping_request</c>
+        ///     message IDs:
+        ///     <code><![CDATA[
+        ///         router.RegisterHandler(
+        ///             "ping_request"
+        ///             async (message) => logger.LogDebug(
+        ///                 "Got ping_request with id {Id}.",
+        ///                 message.Header.Id
+        ///             )
+        ///         );
+        ///     ]]></code>
+        /// </example>
+        public void RegisterHandler(string messageType, Func<Message, Task> handler);
 
         /// <summary>
         ///     Registers a handler that can be used to handle a
@@ -71,7 +116,7 @@ namespace Microsoft.Jupyter.Core
         ///     message type to be handled.
         /// </param>
         public void RegisterHandler(IShellHandler handler) =>
-            RegisterHandler(handler.MessageType, handler.Handle);
+            RegisterHandler(handler.MessageType, handler.HandleAsync);
 
         /// <summary>
         ///     Registers an action to be used to handle messages
@@ -81,7 +126,7 @@ namespace Microsoft.Jupyter.Core
         ///     An action that can be used to handle messages
         ///     whose message types do not have appropriate handlers.
         /// </param>
-        public void RegisterFallback(Action<Message> fallback);
+        public void RegisterFallback(Func<Message, Task> fallback);
 
         /// <summary>
         ///     Calls the appropriate handler for a given message,
@@ -91,7 +136,7 @@ namespace Microsoft.Jupyter.Core
         /// <param name="message">
         ///     The message to be handled.
         /// </param>
-        public void Handle(Message message);
+        public Task HandleAsync(Message message);
 
         /// <summary>
         ///     Searches an assembly for types representing shell

--- a/src/ShellRouting/OrderedShellHandler.cs
+++ b/src/ShellRouting/OrderedShellHandler.cs
@@ -1,0 +1,32 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#nullable enable
+
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Jupyter.Core.Protocol;
+
+namespace Microsoft.Jupyter.Core
+{
+    public abstract class OrderedShellHandler<TResult> : IShellHandler
+    {
+        private Task<TResult>? currentTask = null;
+
+        public abstract Task<TResult> HandleAsync(Message message, TResult? previousResult);
+
+        public Task HandleAsync(Message message)
+        {
+            currentTask = new Task((state) =>
+            {
+                var previousTask = (Task<TResult>?)currentTask;
+                var previousResult = previousTask?.Result;
+                var currentResult = HandleAsync(message, previousResult).Result;
+            }, currentTask);
+            currentTask.Start();
+            return currentTask;
+        }
+    }
+}

--- a/src/ShellRouting/ShellRouter.cs
+++ b/src/ShellRouting/ShellRouter.cs
@@ -46,11 +46,14 @@ namespace Microsoft.Jupyter.Core
             );
         }
 
-        public Task? Handle(Message message) =>
-            (
+        public Task? Handle(Message message)
+        {
+            logger.LogDebug("Handling message of type {MessageType}.", message.Header.MessageType);
+            return (
                 shellHandlers.TryGetValue(message.Header.MessageType, out var handler)
                 ? handler : fallback
             )?.Invoke(message);
+        }
 
         public void RegisterHandler(string messageType, Func<Message, Task?> handler)
         {

--- a/src/ShellRouting/ShellRouter.cs
+++ b/src/ShellRouting/ShellRouter.cs
@@ -20,9 +20,9 @@ namespace Microsoft.Jupyter.Core
     /// </summary>
     public class ShellRouter : IShellRouter
     {
-        private readonly IDictionary<string, Func<Message, Task>> shellHandlers
-            = new Dictionary<string, Func<Message, Task>>();
-        private Func<Message, Task>? fallback;
+        private readonly IDictionary<string, Func<Message, Task?>> shellHandlers
+            = new Dictionary<string, Func<Message, Task?>>();
+        private Func<Message, Task?>? fallback;
         private readonly ILogger<ShellRouter> logger;
         private IServiceProvider services;
 
@@ -46,21 +46,19 @@ namespace Microsoft.Jupyter.Core
             );
         }
 
-        public async Task HandleAsync(Message message)
-        {
-            var task = (
+        public Task? Handle(Message message) =>
+            (
                 shellHandlers.TryGetValue(message.Header.MessageType, out var handler)
                 ? handler : fallback
             )?.Invoke(message);
-            if (task != null) await task;
-        }
 
-        public void RegisterHandler(string messageType, Func<Message, Task> handler)
+        public void RegisterHandler(string messageType, Func<Message, Task?> handler)
         {
             shellHandlers[messageType] = handler;
         }
 
-        public void RegisterFallback(Func<Message, Task> fallback) =>
+        /// <inheritdoc />
+        public void RegisterFallback(Func<Message, Task?> fallback) =>
             this.fallback = fallback;
 
         public void RegisterHandlers<TAssembly>()

--- a/src/Symbols/Magic.cs
+++ b/src/Symbols/Magic.cs
@@ -14,15 +14,27 @@ namespace Microsoft.Jupyter.Core
     /// </summary>
     /// <remarks>
     ///      Each magic command method must have the signature
-    ///      <c>ExecutionResult (string, IChannel)</c>, similar to
+    ///      <c>Task&lt;ExecutionResult&gt; (string, IChannel)</c>, similar to
     ///      <ref>BaseEngine.ExecuteMundane</ref>.
     /// </remarks>
     [System.AttributeUsage(System.AttributeTargets.Method)]
     public class MagicCommandAttribute : System.Attribute
     {
+        /// <summary>
+        ///      Name of the magic command represented by this method.
+        /// </summary>
         public readonly string Name;
+        
+        /// <summary>
+        ///     Documentation to be presented to the user in repsonse to a
+        ///     help command.
+        /// </summary>
         public readonly Documentation Documentation;
 
+        /// <summary>
+        ///      Constructs a new attribute that marks a given method as
+        ///      implementing a given magic command.
+        /// </summary>
         public MagicCommandAttribute(
             string name,
             string summary,
@@ -43,7 +55,10 @@ namespace Microsoft.Jupyter.Core
     /// </summary>
     public class MagicSymbol : ISymbol
     {
+        /// <inheritdoc />
         public string Name { get; set; }
+        
+        /// <inheritdoc />
         public SymbolKind Kind { get; set; }
 
         /// <summary>
@@ -103,6 +118,7 @@ namespace Microsoft.Jupyter.Core
 
         }
 
+        /// <inheritdoc />
         public ISymbol Resolve(string symbolName)
         {
             if (this.methods.ContainsKey(symbolName))

--- a/src/Symbols/Magic.cs
+++ b/src/Symbols/Magic.cs
@@ -141,7 +141,7 @@ namespace Microsoft.Jupyter.Core
                             }
                             catch (Exception)
                             {
-                                throw new InvalidOperationException($"Invalid Magic Method for {symbolName}. Expecting a public method that takes a String and and IChannel as parameters.");
+                                throw new InvalidOperationException($"Invalid magic method for {symbolName}. Expecting a public async method that takes a String and and IChannel as parameters.");
                             }
                         }
                 };

--- a/src/Symbols/Magic.cs
+++ b/src/Symbols/Magic.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Reflection;
+using System.Threading.Tasks;
 using Newtonsoft.Json;
 
 namespace Microsoft.Jupyter.Core
@@ -55,7 +56,7 @@ namespace Microsoft.Jupyter.Core
         ///      user.
         /// </summary>
         [JsonIgnore]
-        public Func<string, IChannel, ExecutionResult> Execute { get; set; }
+        public Func<string, IChannel, Task<ExecutionResult>> Execute { get; set; }
     }
 
     /// <summary>
@@ -116,7 +117,7 @@ namespace Microsoft.Jupyter.Core
                         {
                             try
                             {
-                                return (ExecutionResult)(method.Invoke(engine, new object[] { input, channel }));
+                                return (Task<ExecutionResult>)(method.Invoke(engine, new object[] { input, channel }));
                             } 
                             catch (TargetInvocationException e)
                             {

--- a/src/jupyter-core.csproj
+++ b/src/jupyter-core.csproj
@@ -37,7 +37,7 @@
     <PackageReference Include="System.Net.WebSockets.Client" Version="4.3.1" />
     <PackageReference Include="System.ServiceModel.Primitives" Version="4.5.3" />
 
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-18618-05" PrivateAssets="All"/>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All"/>
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
With #43, we added the ability to provide custom routing, useful for implementing new kinds of shell messages. This turns out to have introduced some subtle deadlocking issues when trying to receive shell messages during the processing of another shell message. To resolve that, this PR makes the _breaking change_ of moving shell and iopub message handling to be entirely async.

This change is especially useful for implementing communication between the client and the kernel during execution requests (e.g.: interactive widgets).