### PR TITLE
Expanded documentation struct and added API documentation comments.

### DIFF
--- a/src/ResultEncoding/SymbolEncoder.cs
+++ b/src/ResultEncoding/SymbolEncoder.cs
@@ -25,7 +25,9 @@ namespace Microsoft.Jupyter.Core
             Icons = new Dictionary<SymbolKind, string>
             {
                 [SymbolKind.Magic] = "fa-magic",
-                [SymbolKind.Other] = "fa-terminal"
+                [SymbolKind.Callable] = "fa-terminal",
+                [SymbolKind.LocalDeclaration] = "fa-stream",
+                [SymbolKind.Other] = "fa-code"
             }.ToImmutableDictionary();
 
         public string MimeType => MimeTypes.Html;

--- a/src/Symbols/ISymbolResolver.cs
+++ b/src/Symbols/ISymbolResolver.cs
@@ -1,28 +1,120 @@
 using System;
+using System.Collections.Generic;
+#nullable enable
 
 namespace Microsoft.Jupyter.Core
 {
+    /// <summary>
+    ///     Identifies the kind of a symbol (e.g.: whether a symbol is a magic
+    ///     symbol).
+    /// </summary>
     public enum SymbolKind
     {
+        /// <summary>
+        ///     Indicates that a symbol is a magic symbol, and not a part of
+        ///     the language supported by an execution engine.
+        /// </summary>
         Magic,
+
+        /// <summary>
+        ///     Indicates that a symbol represents a callable function,
+        ///     operation, method, or similar.
+        /// </summary>
+        Callable,
+
+        /// <summary>
+        ///     Indicates that a symbol represents a local declaration,
+        ///     variable, or similar.
+        /// </summary>
+        LocalDeclaration,
+
+        /// <summary>
+        ///     Indicates that a symbol is does not belong to any other kinds
+        ///     listed in this enum.
+        /// </summary>
         Other
     }
 
+    /// <summary>
+    ///     Documentation for a symbol as resolved by an execution engine.
+    /// </summary>
     public struct Documentation
     {
-        public string Full;
+        /// <summary>
+        ///      Summary for the documented symbol. Should be at most a
+        ///      sentence or two.
+        /// </summary>
         public string Summary;
+
+        [Obsolete("Deprecated, please break into more specific fields as appropriate.")]
+        public string? Full;
+        
+        /// <summary>
+        ///     A detailed description of the documented symbol, formatted as
+        ///     a Markdown document.
+        /// </summary>
+        /// <remarks>
+        ///     This Markdown document should not contain H1 or H2 headers.
+        /// </remarks>
+        public string? Description;
+
+        /// <summary>
+        ///     Additional remarks about the documented symbol, formatted as
+        ///     a Markdown document.
+        /// </summary>
+        /// <remarks>
+        ///     This Markdown document should not contain H1 or H2 headers.
+        /// </remarks>
+        public string? Remarks;
+
+        /// <summary>
+        ///     Examples of how to use the documented symbol, formatted as
+        ///     a sequence of Markdown documents.
+        /// </summary>
+        /// <remarks>
+        ///     The Markdown documents in this field should not contain H1 or
+        ///     H2 headers.
+        /// </remarks>
+        public IEnumerable<string>? Examples;
+
+        /// <summary>
+        ///     Additional links relevant to the documented symbol, formatted
+        ///     as a sequence of links, each with a description and a target.
+        /// </summary>
+        public IEnumerable<(string, Uri)>? SeeAlso;
     }
 
+    /// <summary>
+    ///      Represents a symbol that can be resolved by a symbol resolver,
+    ///      such as a magic symbol, a completion result, or so forth.
+    /// </summary>
     public interface ISymbol
     {
+        /// <summary>
+        ///     The name of the resolved symbol.
+        /// </summary>
         string Name { get; }
+
+        /// <summary>
+        ///      The kind of the resolved symbol (e.g. is it a magic command,
+        ///      a local variable, a function, etc.).
+        /// </summary>
         SymbolKind Kind { get; }
     }
 
+    /// <summary>
+    ///      A service that can be used to resolve symbols from symbol names.
+    /// </summary>
     public interface ISymbolResolver
     {
-        ISymbol Resolve(string symbolName);
+        /// <summary>
+        ///      Resolves a global symbol.
+        /// </summary>
+        /// <returns>
+        ///      The resolved symbol, or <c>null</c> if no such symbol can be
+        ///      successfully resolved.
+        /// </returns>
+        ISymbol? Resolve(string symbolName);
     }
 
 }


### PR DESCRIPTION
This PR expands the documentation struct to provide more detail, paralleling the structure of API reference formats like C#, Q#, PowerShell, etc. As part of that, the `Documentation.Full` field is deprecated in favor of the more detailed breakdown.