### PR TITLE
Allow multiple magic commands per cell and improve whitespace handling

### DIFF
--- a/src/Engines/BaseEngine.cs
+++ b/src/Engines/BaseEngine.cs
@@ -468,6 +468,20 @@ namespace Microsoft.Jupyter.Core
         ///      symbol and its arguments, and <c>remainingInput</c> will
         ///      be populated with any subsequent commands in the cell.
         /// </summary>
+        /// <example>
+        ///      If <c>input</c> contains the following cell contents:
+        ///      <code>
+        ///         %magic arg1 arg2
+        ///         %magic arg3 arg4
+        ///      </code>
+        ///      then the output parameters will be set as follows:
+        ///      <code>
+        ///         symbol = (valid reference to ISymbol)
+        ///         commandInput = "%magic arg1 arg2"
+        ///         remainingInput = "%magic arg3 arg4"
+        ///      </code>
+        ///      and the function will return <c>true</c>.
+        /// </example>
         public virtual bool IsMagic(string input, out ISymbol symbol, out string commandInput, out string remainingInput)
         {
             return this.inputParser.IsMagicOrHelp(input, out symbol, out commandInput, out bool isHelp, out remainingInput)
@@ -486,6 +500,20 @@ namespace Microsoft.Jupyter.Core
         ///      If an input is a request for help on an invalid symbol, then
         ///      this method will return true, but <c>symbol</c> will be null.
         /// </remarks>
+        /// <example>
+        ///      If <c>input</c> contains the following cell contents:
+        ///      <code>
+        ///         %magic? arg1 arg2
+        ///         %magic arg3 arg4
+        ///      </code>
+        ///      then the output parameters will be set as follows:
+        ///      <code>
+        ///         symbol = (valid reference to ISymbol)
+        ///         commandInput = "%magic? arg1 arg2"
+        ///         remainingInput = "%magic arg3 arg4"
+        ///      </code>
+        ///      and the function will return <c>true</c>.
+        /// </example>
         public virtual bool IsHelp(string input, out ISymbol symbol, out string commandInput, out string remainingInput)
         {
             var isMagicOrHelp = this.inputParser.IsMagicOrHelp(input, out symbol, out commandInput, out bool isHelp, out remainingInput);

--- a/src/Engines/BaseEngine.cs
+++ b/src/Engines/BaseEngine.cs
@@ -461,9 +461,12 @@ namespace Microsoft.Jupyter.Core
         #region Command Parsing
 
         /// <summary>
-        ///      Returns <c>true</c> if a given input is magic symbol.
+        ///      Returns <c>true</c> if a given input is a magic symbol.
         ///      If this method returns true, then <c>symbol</c> will
-        ///      be populated with the resolution of the magic symbol.
+        ///      be populated with the resolution of the magic symbol,
+        ///      <c>commandInput</c> will be populated with the magic
+        ///      symbol and its arguments, and <c>remainingInput</c> will
+        ///      be populated with any subsequent commands in the cell.
         /// </summary>
         public virtual bool IsMagic(string input, out ISymbol symbol, out string commandInput, out string remainingInput)
         {
@@ -475,7 +478,9 @@ namespace Microsoft.Jupyter.Core
         ///      Returns <c>true</c> if a given input is a request for help
         ///      on a symbol. If this method returns true, then <c>symbol</c>
         ///      will be populated with the resolution of the symbol targeted
-        ///      for help.
+        ///      for help, <c>commandInput</c> will be populated with the help
+        ///      request and its arguments, and <c>remainingInput</c> will
+        ///      be populated with any subsequent commands in the cell.
         /// </summary>
         /// <remarks>
         ///      If an input is a request for help on an invalid symbol, then

--- a/src/Engines/BaseEngine.cs
+++ b/src/Engines/BaseEngine.cs
@@ -464,7 +464,7 @@ namespace Microsoft.Jupyter.Core
             }
             else
             {
-                var parts = input.Trim().Split(new[] { ' ' }, 2);
+                var parts = input.Trim().Split(null, 2);
                 symbol = Resolve(parts[0]) as MagicSymbol;
             }
 
@@ -570,7 +570,7 @@ namespace Microsoft.Jupyter.Core
             // Which magic command do we have? Split up until the first space.
             if (symbol is MagicSymbol magic)
             {
-                var parts = input.Trim().Split(new[] { ' ' }, 2);
+                var parts = input.Trim().Split(null, 2);
                 var remainingInput = parts.Length > 1 ? parts[1] : "";
                 return await magic.Execute(remainingInput, channel);
             }

--- a/src/Engines/InputParser.cs
+++ b/src/Engines/InputParser.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/Engines/InputParser.cs
+++ b/src/Engines/InputParser.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -16,7 +18,7 @@ namespace Microsoft.Jupyter.Core
             this.Resolver = resolver;
         }
 
-        public bool IsMagicOrHelp(string input, out ISymbol symbol, out string commandInput, out bool isHelp, out string remainingInput)
+        public bool IsMagicOrHelp(string input, out ISymbol? symbol, out string? commandInput, out bool isHelp, out string? remainingInput)
         {
             symbol = null;
             isHelp = false;
@@ -59,7 +61,7 @@ namespace Microsoft.Jupyter.Core
             return true;
         }
 
-        private bool StartsWithMagicOrHelp(string input, out ISymbol symbol, out bool isHelp)
+        private bool StartsWithMagicOrHelp(string input, out ISymbol? symbol, out bool isHelp)
         {
             symbol = null;
             isHelp = false;

--- a/src/Engines/InputParser.cs
+++ b/src/Engines/InputParser.cs
@@ -1,0 +1,85 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Microsoft.Jupyter.Core
+{
+    internal class InputParser
+    {
+        public ISymbolResolver Resolver;
+        
+        public InputParser(ISymbolResolver resolver)
+        {
+            this.Resolver = resolver;
+        }
+
+        public bool IsMagicOrHelp(string input, out ISymbol symbol, out string commandInput, out bool isHelp, out string remainingInput)
+        {
+            symbol = null;
+            isHelp = false;
+            commandInput = input;
+            remainingInput = string.Empty;
+
+            var inputLines = input?.Split(new[] { "\r\n", "\r", "\n" }, StringSplitOptions.None).ToList();
+            if (inputLines == null || inputLines.Count == 0)
+            {
+                return false;
+            }
+
+            // Find the first non-whitespace line and see if it starts with a magic symbol.
+            int firstLineIndex = inputLines.FindIndex(s => !string.IsNullOrWhiteSpace(s));
+            if (firstLineIndex < 0 || !StartsWithMagicOrHelp(inputLines[firstLineIndex], out symbol, out isHelp))
+            {
+                return false;
+            }
+
+            // Look through the remaining lines until we find one that
+            // starts with a magic symbol.
+            commandInput = null;
+            for (int lineIndex = firstLineIndex + 1; lineIndex < inputLines.Count; lineIndex++)
+            {
+                if (StartsWithMagicOrHelp(inputLines[lineIndex], out _, out _))
+                {
+                    commandInput = string.Join(Environment.NewLine, inputLines.SkipLast(inputLines.Count - lineIndex));
+                    remainingInput = string.Join(Environment.NewLine, inputLines.Skip(lineIndex));
+                    break;
+                }
+            }
+
+            // If we didn't find another magic symbol, use the full input
+            // as the command input.
+            if (commandInput == null)
+            {
+                commandInput = input;
+            }
+            
+            return true;
+        }
+
+        private bool StartsWithMagicOrHelp(string input, out ISymbol symbol, out bool isHelp)
+        {
+            symbol = null;
+            isHelp = false;
+
+            var inputParts = input.Trim().Split(null, 2);
+            var symbolName = inputParts[0].Trim();
+            if (symbolName.StartsWith("?"))
+            {
+                symbolName = symbolName.Substring(1, symbolName.Length - 1);
+                isHelp = true;
+            }
+            else if (symbolName.EndsWith("?"))
+            {
+                symbolName = symbolName.Substring(0, symbolName.Length - 1);
+                isHelp = true;
+            }
+
+            if (!string.IsNullOrEmpty(symbolName))
+            {
+                symbol = this.Resolver.Resolve(symbolName) as MagicSymbol;
+            }
+
+            return symbol != null;
+        }            
+    }
+}

--- a/src/Engines/InputParser.cs
+++ b/src/Engines/InputParser.cs
@@ -20,6 +20,8 @@ namespace Microsoft.Jupyter.Core
 
         public bool IsMagicOrHelp(string input, out ISymbol? symbol, out string? commandInput, out bool isHelp, out string? remainingInput)
         {
+            if (input == null) { throw new ArgumentNullException("input"); }
+
             symbol = null;
             isHelp = false;
             commandInput = input;

--- a/tests/core/InputParserTests.cs
+++ b/tests/core/InputParserTests.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 using System;
 using System.Linq;
 using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/tests/core/InputParserTests.cs
+++ b/tests/core/InputParserTests.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Jupyter.Core
             var input = string.Empty;
 
             var inputParser = new InputParser(new MockSymbolResolver());
-            var isMagicOrHelp = inputParser.IsMagicOrHelp(input, out ISymbol symbol, out string commandInput, out bool isHelp, out string remainingInput);
+            var isMagicOrHelp = inputParser.IsMagicOrHelp(input, out ISymbol? symbol, out string? commandInput, out bool isHelp, out string? remainingInput);
             
             Assert.IsFalse(isMagicOrHelp);
             Assert.IsNull(symbol);
@@ -56,7 +56,7 @@ namespace Microsoft.Jupyter.Core
             foreach (var input in inputs)
             {
                 var inputParser = new InputParser(new MockSymbolResolver());
-                var isMagicOrHelp = inputParser.IsMagicOrHelp(input, out ISymbol symbol, out string commandInput, out bool isHelp, out string remainingInput);
+                var isMagicOrHelp = inputParser.IsMagicOrHelp(input, out ISymbol? symbol, out string? commandInput, out bool isHelp, out string? remainingInput);
                 
                 Assert.IsFalse(isMagicOrHelp, $"Input:\n{input}");
                 Assert.IsNull(symbol, $"Input:\n{input}");
@@ -82,7 +82,7 @@ namespace Microsoft.Jupyter.Core
             foreach (var input in inputs)
             {
                 var inputParser = new InputParser(new MockSymbolResolver());
-                var isMagicOrHelp = inputParser.IsMagicOrHelp(input, out ISymbol symbol, out string commandInput, out bool isHelp, out string remainingInput);
+                var isMagicOrHelp = inputParser.IsMagicOrHelp(input, out ISymbol? symbol, out string? commandInput, out bool isHelp, out string? remainingInput);
                 
                 Assert.IsTrue(isMagicOrHelp, $"Input:\n{input}");
                 Assert.IsNotNull(symbol, $"Input:\n{input}");
@@ -104,7 +104,7 @@ namespace Microsoft.Jupyter.Core
             foreach (var input in inputs)
             {
                 var inputParser = new InputParser(new MockSymbolResolver());
-                var isMagicOrHelp = inputParser.IsMagicOrHelp(input, out ISymbol symbol, out string commandInput, out bool isHelp, out string remainingInput);
+                var isMagicOrHelp = inputParser.IsMagicOrHelp(input, out ISymbol? symbol, out string? commandInput, out bool isHelp, out string? remainingInput);
                 
                 Assert.IsTrue(isMagicOrHelp, $"Input:\n{input}");
                 Assert.IsNotNull(symbol, $"Input:\n{input}");
@@ -121,7 +121,7 @@ namespace Microsoft.Jupyter.Core
 
             // simple case
             var input = "%abc\n%def";
-            var isMagicOrHelp = inputParser.IsMagicOrHelp(input, out ISymbol symbol, out string commandInput, out bool isHelp, out string remainingInput);
+            var isMagicOrHelp = inputParser.IsMagicOrHelp(input, out ISymbol? symbol, out string? commandInput, out bool isHelp, out string? remainingInput);
                 
             Assert.IsTrue(isMagicOrHelp, $"Input:\n{input}");
             Assert.IsNotNull(symbol, $"Input:\n{input}");
@@ -146,8 +146,8 @@ namespace Microsoft.Jupyter.Core
             Assert.IsTrue(isMagicOrHelp, $"Input:\n{input}");
             Assert.IsNotNull(symbol, $"Input:\n{input}");
             Assert.IsFalse(isHelp, $"Input:\n{input}");
-            Assert.IsTrue(commandInput.TrimStart().StartsWith("%abc"), $"Input:\n{input}");
-            Assert.IsTrue(remainingInput.TrimStart().StartsWith("%def"), $"Input:\n{input}");
+            Assert.IsTrue(commandInput != null && commandInput.TrimStart().StartsWith("%abc"), $"Input:\n{input}");
+            Assert.IsTrue(remainingInput != null && remainingInput.TrimStart().StartsWith("%def"), $"Input:\n{input}");
         }
     }
 }

--- a/tests/core/InputParserTests.cs
+++ b/tests/core/InputParserTests.cs
@@ -1,0 +1,153 @@
+using System;
+using System.Linq;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.Jupyter.Core
+{
+    internal class MockSymbolResolver : ISymbolResolver
+    {
+        private string[] magicSymbols = new[] { "%abc", "%def" };
+
+        public ISymbol Resolve(string symbolName)
+        {
+            if (this.magicSymbols.Contains(symbolName))
+            {
+                return new MagicSymbol
+                {
+                    Name = symbolName,
+                    Documentation = new Documentation(),
+                    Kind = SymbolKind.Magic,
+                    Execute = async (input, channel) => { return ExecutionResult.Aborted; }
+                };
+            }
+
+            return null;
+        }
+    }
+
+    [TestClass]
+    public class InputParserTests
+    {
+        [TestMethod]
+        public void TestEmptyInput()
+        {
+            var input = string.Empty;
+
+            var inputParser = new InputParser(new MockSymbolResolver());
+            var isMagicOrHelp = inputParser.IsMagicOrHelp(input, out ISymbol symbol, out string commandInput, out bool isHelp, out string remainingInput);
+            
+            Assert.IsFalse(isMagicOrHelp);
+            Assert.IsNull(symbol);
+            Assert.IsFalse(isHelp);
+            Assert.AreEqual(commandInput, string.Empty);
+            Assert.AreEqual(remainingInput, string.Empty);
+        }
+
+        [TestMethod]
+        public void TestInvalidMagic()
+        {
+            var inputs = new[] { 
+                "%notamagic",            // invalid magic
+                "% abc",                 // magic with space
+                "text %abc",             // magic not at the beginning of a line
+                "%abc%def",              // magic without trailing whitespace
+            };
+
+            foreach (var input in inputs)
+            {
+                var inputParser = new InputParser(new MockSymbolResolver());
+                var isMagicOrHelp = inputParser.IsMagicOrHelp(input, out ISymbol symbol, out string commandInput, out bool isHelp, out string remainingInput);
+                
+                Assert.IsFalse(isMagicOrHelp, $"Input:\n{input}");
+                Assert.IsNull(symbol, $"Input:\n{input}");
+                Assert.IsFalse(isHelp, $"Input:\n{input}");
+                Assert.AreEqual(commandInput, input, $"Input:\n{input}");
+                Assert.AreEqual(remainingInput, string.Empty, $"Input:\n{input}");
+            }
+        }
+
+        [TestMethod]
+        public void TestSingleMagic()
+        {
+            var inputs = new[] { 
+                "%abc",                            // simple case
+                "%abc arg",                        // simple case with argument
+                "%abc ?",                          // simple case with argument, not help because of whitespace
+                " \t %abc",                        // leading whitespace should have no impact
+                " \r\n %def \n arg ",              // leading line breaks should have no impact
+                "%def arg \n\t %notamagic arg",    // invalid magic should be treated as plain text
+                "%abc arg %def arg",               // magic in middle of line should not be detected
+            };
+
+            foreach (var input in inputs)
+            {
+                var inputParser = new InputParser(new MockSymbolResolver());
+                var isMagicOrHelp = inputParser.IsMagicOrHelp(input, out ISymbol symbol, out string commandInput, out bool isHelp, out string remainingInput);
+                
+                Assert.IsTrue(isMagicOrHelp, $"Input:\n{input}");
+                Assert.IsNotNull(symbol, $"Input:\n{input}");
+                Assert.IsFalse(isHelp, $"Input:\n{input}");
+                Assert.AreEqual(commandInput, input, $"Input:\n{input}");
+                Assert.AreEqual(remainingInput, string.Empty, $"Input:\n{input}");
+            }
+        }
+
+        [TestMethod]
+        public void TestSingleHelp()
+        {
+            var inputs = new[] { 
+                "?%abc",                    // leading ?
+                "%abc?",                    // trailing ?
+                " \r\n  %abc? arg \n",      // leading whitespace and trailing text
+            };
+
+            foreach (var input in inputs)
+            {
+                var inputParser = new InputParser(new MockSymbolResolver());
+                var isMagicOrHelp = inputParser.IsMagicOrHelp(input, out ISymbol symbol, out string commandInput, out bool isHelp, out string remainingInput);
+                
+                Assert.IsTrue(isMagicOrHelp, $"Input:\n{input}");
+                Assert.IsNotNull(symbol, $"Input:\n{input}");
+                Assert.IsTrue(isHelp, $"Input:\n{input}");
+                Assert.AreEqual(commandInput, input, $"Input:\n{input}");
+                Assert.AreEqual(remainingInput, string.Empty, $"Input:\n{input}");
+            }
+        }
+
+        [TestMethod]
+        public void TestMultipleMagics()
+        {
+            var inputParser = new InputParser(new MockSymbolResolver());
+
+            // simple case
+            var input = "%abc\n%def";
+            var isMagicOrHelp = inputParser.IsMagicOrHelp(input, out ISymbol symbol, out string commandInput, out bool isHelp, out string remainingInput);
+                
+            Assert.IsTrue(isMagicOrHelp, $"Input:\n{input}");
+            Assert.IsNotNull(symbol, $"Input:\n{input}");
+            Assert.IsFalse(isHelp, $"Input:\n{input}");
+            Assert.AreEqual(commandInput, "%abc", $"Input:\n{input}");
+            Assert.AreEqual(remainingInput, "%def", $"Input:\n{input}");
+
+            // simple case with help
+            input = "%abc?\n%def";
+            isMagicOrHelp = inputParser.IsMagicOrHelp(input, out symbol, out commandInput, out isHelp, out remainingInput);
+                
+            Assert.IsTrue(isMagicOrHelp, $"Input:\n{input}");
+            Assert.IsNotNull(symbol, $"Input:\n{input}");
+            Assert.IsTrue(isHelp, $"Input:\n{input}");
+            Assert.AreEqual(commandInput, "%abc?", $"Input:\n{input}");
+            Assert.AreEqual(remainingInput, "%def", $"Input:\n{input}");
+
+            // multi-line args and extra whitespace
+            input = " \n  %abc \r\n arg1 \n\t arg2  \r\n  \t  %def arg3 arg4";
+            isMagicOrHelp = inputParser.IsMagicOrHelp(input, out symbol, out commandInput, out isHelp, out remainingInput);
+                
+            Assert.IsTrue(isMagicOrHelp, $"Input:\n{input}");
+            Assert.IsNotNull(symbol, $"Input:\n{input}");
+            Assert.IsFalse(isHelp, $"Input:\n{input}");
+            Assert.IsTrue(commandInput.TrimStart().StartsWith("%abc"), $"Input:\n{input}");
+            Assert.IsTrue(remainingInput.TrimStart().StartsWith("%def"), $"Input:\n{input}");
+        }
+    }
+}

--- a/tests/core/InputParserTests.cs
+++ b/tests/core/InputParserTests.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+#nullable enable
+
 using System;
 using System.Linq;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -11,21 +13,16 @@ namespace Microsoft.Jupyter.Core
     {
         private string[] magicSymbols = new[] { "%abc", "%def" };
 
-        public ISymbol Resolve(string symbolName)
-        {
-            if (this.magicSymbols.Contains(symbolName))
-            {
-                return new MagicSymbol
+        public ISymbol? Resolve(string symbolName) =>
+            this.magicSymbols.Contains(symbolName)
+            ? new MagicSymbol
                 {
                     Name = symbolName,
                     Documentation = new Documentation(),
                     Kind = SymbolKind.Magic,
-                    Execute = async (input, channel) => ExecutionResult.Aborted;
-                };
-            }
-
-            return null;
-        }
+                    Execute = async (input, channel) => ExecutionResult.Aborted
+                }
+            : null;
     }
 
     [TestClass]


### PR DESCRIPTION
This PR modifies the BaseEngine in jupyter-core to support the presence of multiple magic and/or help commands in a single cell execution. It also allows arguments for magic commands to span multiple lines.

The existing parsing logic from BaseEngine has been moved into a new InputParser class, the new functionality has been added there, and tests for the new class have also been added.