### PR TITLE
Add support for text alignment in table cells

### DIFF
--- a/src/ResultEncoding/Table.cs
+++ b/src/ResultEncoding/Table.cs
@@ -6,6 +6,71 @@ using Newtonsoft.Json;
 
 namespace Microsoft.Jupyter.Core
 {
+    /// <summary>
+    /// Specifies the text alignment to use for a table cell.
+    /// </summary>
+    public enum TableCellAlignment
+    {
+        /// <summary>
+        /// Align text to the left of the cell.
+        /// </summary>
+        Left,
+
+        /// <summary>
+        /// Align text to the right of the cell.
+        /// </summary>
+        Right,
+
+        /// <summary>
+        /// No alignment specified.
+        /// </summary>
+        None
+    }
+
+    public static class TableCellAlignmentExtensions
+    {
+        /// <summary>
+        /// Constructs an HTML style attribute implementing the specified <see cref="TableCellAlignment"/>.
+        /// </summary>
+        /// <param name="alignment">The desired cell alignment.</param>
+        /// <returns>
+        /// A string containing the full HTML style attribute name and value, or an empty string
+        /// if the alignment is specified as <see cref="TableCellAlignment.None"/>.
+        /// </returns>
+        /// <remarks>
+        /// This method uses <c>start</c> and <c>end</c> values for the <c>text-align</c> CSS attribute,
+        /// which respect the reading direction (LTR or RTL) of the surrounding HTML. For example, if the 
+        /// specified alignment is <see cref="TableCellAlignment.Left"/>, the text will be aligned to the left
+        /// in LTR and to the right in RTL.
+        /// </remarks>
+        public static string ToStyleAttribute(this TableCellAlignment alignment) => alignment switch
+        {
+            TableCellAlignment.Left => "style=\"text-align: start;\"",
+            TableCellAlignment.Right => "style=\"text-align: end;\"",
+            _ => string.Empty
+        };
+
+        /// <summary>
+        /// Delegates to either <see cref="string.PadLeft(int)"/> or <see cref="string.PadRight(int)"/>, depending
+        /// on the specified <see cref="TableCellAlignment"/> value.
+        /// </summary>
+        /// <param name="cell">A string representing the table cell contents.</param>
+        /// <param name="totalWidth">The total width of the cell, in characters.</param>
+        /// <param name="alignment">Specifies the desired text alignment in the cell</param>
+        /// <returns>
+        /// The padded string returned from <see cref="string.PadLeft(int)"/> or <see cref="string.PadRight(int)"/>.
+        /// </returns>
+        /// <remarks>
+        /// If the specified alignment is <see cref="TableCellAlignment.None"/>, the text will be aligned to the left.
+        /// </remarks>
+        public static string PadCell(this string cell, int totalWidth, TableCellAlignment alignment) => alignment switch
+        {
+            TableCellAlignment.Left => cell.PadRight(totalWidth),
+            TableCellAlignment.Right => cell.PadLeft(totalWidth),
+            _ => cell.PadRight(totalWidth)
+        };
+    }
+    
     public interface ITable
     {
         string[] Headers { get; }
@@ -40,6 +105,9 @@ namespace Microsoft.Jupyter.Core
     public class TableToHtmlDisplayEncoder : IResultEncoder
     {
         public string MimeType => MimeTypes.Html;
+        
+        public TableCellAlignment TableCellAlignment { get; set; } = TableCellAlignment.Left;
+
         public EncodedData? Encode(object displayable)
         {
             if (displayable is ITable table)
@@ -55,7 +123,7 @@ namespace Microsoft.Jupyter.Core
                                 "<tr>" +
                                     String.Join("",
                                         headers.Select(
-                                            header => $"<th>{header}</th>"
+                                            header => $"<th {TableCellAlignment.ToStyleAttribute()}>{header}</th>"
                                         )
                                     ) +
                                 "</tr>" +
@@ -66,7 +134,7 @@ namespace Microsoft.Jupyter.Core
                                         "<tr>" +
                                         String.Join("",
                                             row.Select(
-                                                cell => $"<td>{cell}</td>"
+                                                cell => $"<td {TableCellAlignment.ToStyleAttribute()}>{cell}</td>"
                                             )
                                         ) +
                                         "</tr>"
@@ -82,6 +150,9 @@ namespace Microsoft.Jupyter.Core
     public class TableToTextDisplayEncoder : IResultEncoder
     {
         public string MimeType => MimeTypes.PlainText;
+        
+        public TableCellAlignment TableCellAlignment { get; set; } = TableCellAlignment.Left;
+
         public EncodedData? Encode(object displayable)
         {
             if (displayable is ITable table)
@@ -106,7 +177,7 @@ namespace Microsoft.Jupyter.Core
                 var text = new StringBuilder();
                 text.Append(String.Join(" ",
                     headers.Select((header, idxCol) =>
-                        header.PadRight(widths[idxCol])
+                        header.PadCell(widths[idxCol], TableCellAlignment)
                     )
                 ).TrimEnd());
                 text.Append(Environment.NewLine);
@@ -118,7 +189,7 @@ namespace Microsoft.Jupyter.Core
                 {
                     text.Append(String.Join(" ",
                         row.Select(
-                            (cell, idxCol) => cell.PadRight(widths[idxCol])
+                            (cell, idxCol) => cell.PadCell(widths[idxCol], TableCellAlignment)
                         )
                     ).TrimEnd());
                     text.Append(Environment.NewLine);

--- a/tests/core/EncoderTests.cs
+++ b/tests/core/EncoderTests.cs
@@ -103,23 +103,44 @@ namespace Microsoft.Jupyter.Core
         }
 
         [TestMethod]
-        public void TestTableToHtml()
+        public void TestTableToTextRightAlign()
         {
-            var encoder = new TableToHtmlDisplayEncoder();
-            Assert.AreEqual(encoder.MimeType, MimeTypes.Html);
+            var encoder = new TableToTextDisplayEncoder() { TableCellAlignment = TableCellAlignment.Right };
+            Assert.AreEqual(encoder.MimeType, MimeTypes.PlainText);
             Assert.IsNull(encoder.Encode(null));
             var data = encoder.Encode(exampleTable);
             Assert.IsTrue(data.HasValue);
-            var expected =
-                "<table>" +
-                    "<thead><tr><th>foo</th><th>bar</th></tr></thead>" +
-                    "<tbody>" +
-                        "<tr><td>42</td><td>3.14</td></tr>" +
-                        "<tr><td>1337</td><td>2.718</td></tr>" +
-                    "</tbody>" +
-                "</table>";
+            var expected = @" foo   bar
+---- -----
+  42  3.14
+1337 2.718
+";
             Assert.AreEqual(data.Value.Data, expected);
             Assert.AreEqual(data.Value.Metadata, null);
+        }
+
+        [TestMethod]
+        public void TestTableToHtml()
+        {
+            foreach (TableCellAlignment alignment in typeof(TableCellAlignment).GetEnumValues())
+            {
+                var encoder = new TableToHtmlDisplayEncoder() { TableCellAlignment = alignment };
+                Assert.AreEqual(encoder.MimeType, MimeTypes.Html);
+                Assert.IsNull(encoder.Encode(null));
+                var data = encoder.Encode(exampleTable);
+                Assert.IsTrue(data.HasValue);
+                var style = alignment.ToStyleAttribute();
+                var expected =
+                    "<table>" +
+                        $"<thead><tr><th {style}>foo</th><th {style}>bar</th></tr></thead>" +
+                        "<tbody>" +
+                            $"<tr><td {style}>42</td><td {style}>3.14</td></tr>" +
+                            $"<tr><td {style}>1337</td><td {style}>2.718</td></tr>" +
+                        "</tbody>" +
+                    "</table>";
+                Assert.AreEqual(data.Value.Data, expected);
+                Assert.AreEqual(data.Value.Metadata, null);
+            }
         }
 
         [TestMethod]


### PR DESCRIPTION
Resolves #51 by adding a `TableCellAlignment` property to the table encoders. I'm choosing the default to be `TableCellAlignment.Left`. Left-align was already the default for the TableToText variant, but the TableToHTML variant ended up defaulting to right-align due to default Jupyter Notebook styling. For consistency, these should have the same default, and left-align seems to be the most logical default.