### PR TITLE
Add documentation fields to magic command HTML encoding

### DIFF
--- a/src/ResultEncoding/SymbolEncoder.cs
+++ b/src/ResultEncoding/SymbolEncoder.cs
@@ -1,9 +1,10 @@
 using System.Collections.Immutable;
 using System.Collections.Generic;
+using System.Linq;
+using Markdig;
 
 namespace Microsoft.Jupyter.Core
 {
-
     public class MagicSymbolToTextResultEncoder : IResultEncoder
     {
         public string MimeType => MimeTypes.PlainText;
@@ -17,6 +18,19 @@ namespace Microsoft.Jupyter.Core
             }
             else return null;
         }
+    }
+
+    internal static class MarkdownExtensions
+    {
+        public static string ToMarkdownHtml(this string markdown, string heading) =>
+            !string.IsNullOrEmpty(markdown)
+            ? heading + Markdown.ToHtml(markdown)
+            : string.Empty;
+
+        public static string ToMarkdownHtml(this IEnumerable<string> markdown, string heading) =>
+            markdown != null && markdown.Any()
+            ? string.Join(string.Empty, markdown.Select(m => m.ToMarkdownHtml(heading)))
+            : string.Empty;
     }
 
     public class MagicSymbolToHtmlResultEncoder : IResultEncoder
@@ -39,7 +53,10 @@ namespace Microsoft.Jupyter.Core
 
                 return (
                     $"<h4><i class=\"fa fas {Icons[symbol.Kind]}\"></i> {symbol.Name}</h4>" +
-                    $"<p>{symbol.Documentation.Summary ?? ""}</p>"
+                    $"<p>{symbol.Documentation.Summary ?? ""}</p>" +
+                    symbol.Documentation.Description.ToMarkdownHtml("<h5>Description</h5>") +
+                    symbol.Documentation.Remarks.ToMarkdownHtml("<h5>Remarks</h5>") +
+                    symbol.Documentation.Examples.ToMarkdownHtml("<h5>Example</h5>")
                 ).ToEncodedData();
 
             }

--- a/src/jupyter-core.csproj
+++ b/src/jupyter-core.csproj
@@ -24,6 +24,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Markdig" Version="0.20.0" />
     <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="2.2.5" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="3.0.0" />

--- a/tests/core/EncoderTests.cs
+++ b/tests/core/EncoderTests.cs
@@ -177,6 +177,12 @@ namespace Microsoft.Jupyter.Core
             return new MagicSymbolToHtmlResultEncoder().Encode(magic)?.Data ?? string.Empty;
         }
 
+        private void AssertContainsAll(string fullString, params string[] values) =>
+            Assert.IsTrue(values.All(v => fullString.Contains(v)));
+
+        private void AssertContainsNone(string fullString, params string[] values) =>
+            Assert.IsFalse(values.Any(v => fullString.Contains(v)));
+
         [TestMethod]
         public void TestMagicEncoder()
         {
@@ -186,52 +192,32 @@ namespace Microsoft.Jupyter.Core
 
             var documentation = new Documentation();
             var encoding = EncodeTestMagic(documentation);
-            Assert.IsFalse(encoding.Contains(headingDescription));
-            Assert.IsFalse(encoding.Contains(headingRemarks));
-            Assert.IsFalse(encoding.Contains(headingExample));
+            AssertContainsNone(encoding, headingDescription, headingRemarks, headingExample);
 
             documentation.Summary = "Test summary.";
             encoding = EncodeTestMagic(documentation);
-            Assert.IsTrue(encoding.Contains(documentation.Summary));
-            Assert.IsFalse(encoding.Contains(headingDescription));
-            Assert.IsFalse(encoding.Contains(headingRemarks));
-            Assert.IsFalse(encoding.Contains(headingExample));
+            AssertContainsAll(encoding, documentation.Summary);
+            AssertContainsNone(encoding, headingDescription, headingRemarks, headingExample);
 
             documentation.Description = "Test description.";
             encoding = EncodeTestMagic(documentation);
-            Assert.IsTrue(encoding.Contains(documentation.Summary));
-            Assert.IsTrue(encoding.Contains(documentation.Description));
-            Assert.IsTrue(encoding.Contains(headingDescription));
-            Assert.IsFalse(encoding.Contains(headingRemarks));
-            Assert.IsFalse(encoding.Contains(headingExample));
+            AssertContainsAll(encoding, documentation.Summary, documentation.Description, headingDescription);
+            AssertContainsNone(encoding, headingRemarks, headingExample);
 
             documentation.Remarks = "Test remarks.";
             encoding = EncodeTestMagic(documentation);
-            Assert.IsTrue(encoding.Contains(documentation.Summary));
-            Assert.IsTrue(encoding.Contains(documentation.Description));
-            Assert.IsTrue(encoding.Contains(documentation.Remarks));
-            Assert.IsTrue(encoding.Contains(headingDescription));
-            Assert.IsTrue(encoding.Contains(headingRemarks));
-            Assert.IsFalse(encoding.Contains(headingExample));
+            AssertContainsAll(encoding, documentation.Summary, documentation.Description, documentation.Remarks, headingDescription, headingRemarks);
+            AssertContainsNone(encoding, headingExample);
 
             documentation.Examples = new List<string>();
             encoding = EncodeTestMagic(documentation);
-            Assert.IsTrue(encoding.Contains(documentation.Summary));
-            Assert.IsTrue(encoding.Contains(documentation.Description));
-            Assert.IsTrue(encoding.Contains(documentation.Remarks));
-            Assert.IsTrue(encoding.Contains(headingDescription));
-            Assert.IsTrue(encoding.Contains(headingRemarks));
-            Assert.IsFalse(encoding.Contains(headingExample));
+            AssertContainsAll(encoding, documentation.Summary, documentation.Description, documentation.Remarks, headingDescription, headingRemarks);
+            AssertContainsNone(encoding, headingExample);
 
             documentation.Examples = new List<string>() { "First example.", "Second example." };
             encoding = EncodeTestMagic(documentation);
-            Assert.IsTrue(encoding.Contains(documentation.Summary));
-            Assert.IsTrue(encoding.Contains(documentation.Description));
-            Assert.IsTrue(encoding.Contains(documentation.Remarks));
-            Assert.IsTrue(encoding.Contains(headingDescription));
-            Assert.IsTrue(encoding.Contains(headingRemarks));
-            Assert.IsTrue(encoding.Contains(headingExample));
-            Assert.IsTrue(documentation.Examples.All(example => encoding.Contains(example)));
+            AssertContainsAll(encoding, documentation.Summary, documentation.Description, documentation.Remarks, headingDescription, headingRemarks);
+            AssertContainsAll(encoding, documentation.Examples.ToArray());
         }
     }
 }

--- a/tests/core/EncoderTests.cs
+++ b/tests/core/EncoderTests.cs
@@ -164,5 +164,74 @@ namespace Microsoft.Jupyter.Core
                 Assert.IsTrue(encoder.Icons.ContainsKey(kind));
             }
         }
+
+        private string EncodeTestMagic(Documentation documentation)
+        {
+            var magic = new MagicSymbol
+            {
+                Name = "%test",
+                Documentation = documentation,
+                Kind = SymbolKind.Magic,
+                Execute = async (input, channel) => ExecutionResult.Aborted
+            };
+            return new MagicSymbolToHtmlResultEncoder().Encode(magic)?.Data ?? string.Empty;
+        }
+
+        [TestMethod]
+        public void TestMagicEncoder()
+        {
+            var headingDescription = "<h5>Description</h5>";
+            var headingRemarks = "<h5>Remarks</h5>";
+            var headingExample = "<h5>Example</h5>";
+
+            var documentation = new Documentation();
+            var encoding = EncodeTestMagic(documentation);
+            Assert.IsFalse(encoding.Contains(headingDescription));
+            Assert.IsFalse(encoding.Contains(headingRemarks));
+            Assert.IsFalse(encoding.Contains(headingExample));
+
+            documentation.Summary = "Test summary.";
+            encoding = EncodeTestMagic(documentation);
+            Assert.IsTrue(encoding.Contains(documentation.Summary));
+            Assert.IsFalse(encoding.Contains(headingDescription));
+            Assert.IsFalse(encoding.Contains(headingRemarks));
+            Assert.IsFalse(encoding.Contains(headingExample));
+
+            documentation.Description = "Test description.";
+            encoding = EncodeTestMagic(documentation);
+            Assert.IsTrue(encoding.Contains(documentation.Summary));
+            Assert.IsTrue(encoding.Contains(documentation.Description));
+            Assert.IsTrue(encoding.Contains(headingDescription));
+            Assert.IsFalse(encoding.Contains(headingRemarks));
+            Assert.IsFalse(encoding.Contains(headingExample));
+
+            documentation.Remarks = "Test remarks.";
+            encoding = EncodeTestMagic(documentation);
+            Assert.IsTrue(encoding.Contains(documentation.Summary));
+            Assert.IsTrue(encoding.Contains(documentation.Description));
+            Assert.IsTrue(encoding.Contains(documentation.Remarks));
+            Assert.IsTrue(encoding.Contains(headingDescription));
+            Assert.IsTrue(encoding.Contains(headingRemarks));
+            Assert.IsFalse(encoding.Contains(headingExample));
+
+            documentation.Examples = new List<string>();
+            encoding = EncodeTestMagic(documentation);
+            Assert.IsTrue(encoding.Contains(documentation.Summary));
+            Assert.IsTrue(encoding.Contains(documentation.Description));
+            Assert.IsTrue(encoding.Contains(documentation.Remarks));
+            Assert.IsTrue(encoding.Contains(headingDescription));
+            Assert.IsTrue(encoding.Contains(headingRemarks));
+            Assert.IsFalse(encoding.Contains(headingExample));
+
+            documentation.Examples = new List<string>() { "First example.", "Second example." };
+            encoding = EncodeTestMagic(documentation);
+            Assert.IsTrue(encoding.Contains(documentation.Summary));
+            Assert.IsTrue(encoding.Contains(documentation.Description));
+            Assert.IsTrue(encoding.Contains(documentation.Remarks));
+            Assert.IsTrue(encoding.Contains(headingDescription));
+            Assert.IsTrue(encoding.Contains(headingRemarks));
+            Assert.IsTrue(encoding.Contains(headingExample));
+            Assert.IsTrue(documentation.Examples.All(example => encoding.Contains(example)));
+        }
     }
 }


### PR DESCRIPTION
Magic commands have a detailed `Documentation` struct thanks to @cgranade's work, but only the `Summary` property is printed when running a help command such as `%magic?`.

This PR adds the remaining documentation fields (`Description`, `Remarks`, and `Examples`) to the HTML encoding, if they exist.

Here's an example of how it looks, using the [`%config` magic from IQ#](https://github.com/microsoft/iqsharp/blob/78bc32d8a6b1fb3727fe7dfa81afb4f317a007eb/src/Kernel/Magic/ConfigMagic.cs#L28-L71) as an example:

![image](https://user-images.githubusercontent.com/3620100/84837009-d4c3d280-afeb-11ea-99dc-280e8f31d916.png)
