### PR TITLE
Handle kernel interrupt messages

### DIFF
--- a/src/Data/Metadata.cs
+++ b/src/Data/Metadata.cs
@@ -36,6 +36,9 @@ namespace Microsoft.Jupyter.Core
 
         [JsonProperty("language")]
         public string LanguageName;
+
+        [JsonProperty("interrupt_mode")]
+        public string InterruptMode = "message";
     }
 
     /// <summary>

--- a/src/Data/Protocol.cs
+++ b/src/Data/Protocol.cs
@@ -88,6 +88,7 @@ namespace Microsoft.Jupyter.Core.Protocol
             {
                 ["kernel_info_request"] = data => new EmptyContent(),
                 ["execute_request"] = data => JsonConvert.DeserializeObject<ExecuteRequestContent>(data),
+                ["interrupt_request"] = data => new EmptyContent(),
                 ["shutdown_request"] = data => JsonConvert.DeserializeObject<ShutdownRequestContent>(data)
             }.ToImmutableDictionary();
     }

--- a/src/Servers/IShellServer.cs
+++ b/src/Servers/IShellServer.cs
@@ -8,6 +8,8 @@ namespace Microsoft.Jupyter.Core
     public interface IShellServer
     {
         event Action<Message> KernelInfoRequest;
+        
+        event Action<Message> InterruptRequest;
 
         event Action<Message> ShutdownRequest;
 

--- a/src/Servers/ShellServer.cs
+++ b/src/Servers/ShellServer.cs
@@ -68,6 +68,7 @@ namespace Microsoft.Jupyter.Core
             this.router = router;
 
             router.RegisterHandler("kernel_info_request", async message => KernelInfoRequest?.Invoke(message));
+            router.RegisterHandler("interrupt_request", async message => InterruptRequest?.Invoke(message));
             router.RegisterHandler("shutdown_request", async message => ShutdownRequest?.Invoke(message));
         }
 
@@ -157,6 +158,7 @@ namespace Microsoft.Jupyter.Core
         private bool disposedValue = false; // To detect redundant calls
 
         public event Action<Message> KernelInfoRequest;
+        public event Action<Message> InterruptRequest;
         public event Action<Message> ShutdownRequest;
 
         protected virtual void Dispose(bool disposing)


### PR DESCRIPTION
Resolves #55 by setting `interrupt_mode` to `message` in the kernelspec and handling the `interrupt_request` message from the Jupyter client, as documented [here](https://jupyter-client.readthedocs.io/en/stable/messaging.html#kernel-interrupt).