### PR TITLE
Add SendIoPubMessage to IChannel

### DIFF
--- a/src/Engines/BaseEngine.cs
+++ b/src/Engines/BaseEngine.cs
@@ -96,6 +96,11 @@ namespace Microsoft.Jupyter.Core
             {
                 engine.WriteToStream(parent, StreamName.StandardOut, message);
             }
+
+            public void SendIoPubMessage(Message message)
+            {
+                engine.ShellServer.SendIoPubMessage(message.AsReplyTo(parent));
+            }
         }
 
         /// <summary>

--- a/src/Engines/IChannel.cs
+++ b/src/Engines/IChannel.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using Microsoft.Jupyter.Core.Protocol;
 
 namespace Microsoft.Jupyter.Core
@@ -82,6 +83,6 @@ namespace Microsoft.Jupyter.Core
         ///     Sends an iopub message to the client associated with this channel.
         /// </summary>
         /// <param name="message">The message to send. Cannot be null.</param>
-        void SendIoPubMessage(Message message);
+        void SendIoPubMessage(Message message) => throw new NotImplementedException();
     }
 }

--- a/src/Engines/IChannel.cs
+++ b/src/Engines/IChannel.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using Microsoft.Jupyter.Core.Protocol;
+
 namespace Microsoft.Jupyter.Core
 {
     /// <summary>
@@ -41,8 +43,8 @@ namespace Microsoft.Jupyter.Core
 
     /// <summary>
     ///      Specifies a display channel between a Jupyter kernel and its clients
-    ///      that can be used for printing to streams and for displaying
-    ///      rich data.
+    ///      that can be used for printing to streams, displaying rich data, and
+    ///      sending messages.
     /// </summary>
     public interface IChannel
     {
@@ -75,5 +77,11 @@ namespace Microsoft.Jupyter.Core
             this.Display(displayable);
             return new UpdatableDisplayFallback(this);
         }
+
+        /// <summary>
+        ///     Sends an iopub message to the client associated with this channel.
+        /// </summary>
+        /// <param name="message">The message to send. Cannot be null.</param>
+        void SendIoPubMessage(Message message);
     }
 }

--- a/src/Extensions/ChannelWithNewLines.cs
+++ b/src/Extensions/ChannelWithNewLines.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Collections.Generic;
 using System.Text;
+using Microsoft.Jupyter.Core.Protocol;
 
 namespace Microsoft.Jupyter.Core
 {
@@ -91,5 +92,8 @@ namespace Microsoft.Jupyter.Core
         ///     An object that can be used to update the display in the future.
         /// </returns>
         public IUpdatableDisplay DisplayUpdatable(object displayable) => BaseChannel?.DisplayUpdatable(displayable);
+
+        /// <inheritdoc/>
+        public void SendIoPubMessage(Message message) => BaseChannel?.SendIoPubMessage(message);
     }
 }


### PR DESCRIPTION
This PR adds a method to `IChannel` allowing consumers to send an iopub message to the client associated with the channel, using the `AsReplyTo` method to correctly populate the `ZmqIdentities`, `ParentHeader`, and `Header.Session` properties of the message.