### PR TITLE
Use Markdig.Signed

### DIFF
--- a/src/jupyter-core.csproj
+++ b/src/jupyter-core.csproj
@@ -24,7 +24,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Markdig" Version="0.20.0" />
+    <PackageReference Include="Markdig.Signed" Version="0.20.0" />
     <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="2.2.5" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="3.0.0" />


### PR DESCRIPTION
Avoids incompatibility with packages using a different version of the unsigned `Markdig` package, which can't be loaded side-by-side.