### PR TITLE
Fix timing issue between OrderedShellHandler and execute_reply message

### DIFF
--- a/src/Engines/ExecuteRequestHandler.cs
+++ b/src/Engines/ExecuteRequestHandler.cs
@@ -204,6 +204,7 @@ namespace Microsoft.Jupyter.Core
             if (previousResult != null && previousResult.Value.Status != ExecuteStatus.Ok)
             {
                 this.logger.LogDebug("Aborting due to previous execution result indicating failure: {PreviousResult}", previousResult.Value);
+                onHandled();
                 await SendAbortMessage(message);
                 return ExecutionResult.Aborted;
             }

--- a/src/Engines/ExecuteRequestHandler.cs
+++ b/src/Engines/ExecuteRequestHandler.cs
@@ -47,7 +47,7 @@ namespace Microsoft.Jupyter.Core
 
         public override string MessageType => "execute_request";
         
-        protected async virtual Task<ExecutionResult> ExecutionTaskForMessage(Message message, int executionCount)
+        protected async virtual Task<ExecutionResult> ExecutionTaskForMessage(Message message, int executionCount, Action onHandled)
         {
             var engineResponse = ExecutionResult.Aborted;
 
@@ -101,6 +101,12 @@ namespace Microsoft.Jupyter.Core
                     }
                 );
             }
+
+            // Invoke the onHandled callback prior to sending the execute_reply message.
+            // This guarantees that the OrderedShellHandler correctly clears this task from its
+            // currentTask reference *before* any new task that the client may submit for
+            // execution immediately upon receiving the execute_reply message.
+            onHandled();
 
             // Handle the message.
             this.shellServer.SendShellMessage(
@@ -188,7 +194,10 @@ namespace Microsoft.Jupyter.Core
             }
         }
 
-        public override async Task<ExecutionResult> HandleAsync(Message message, ExecutionResult? previousResult)
+        public override async Task<ExecutionResult> HandleAsync(Message message, ExecutionResult? previousResult) =>
+            await HandleAsync(message, previousResult, () => {});
+
+        public override async Task<ExecutionResult> HandleAsync(Message message, ExecutionResult? previousResult, Action onHandled)
         {
             this.logger.LogDebug($"Asked to execute code:\n{((ExecuteRequestContent)message.Content).Code}");
 
@@ -204,7 +213,7 @@ namespace Microsoft.Jupyter.Core
 
             try
             {
-                var result = await ExecutionTaskForMessage(message, executionCount);
+                var result = await ExecutionTaskForMessage(message, executionCount, onHandled);
                 return result;
             }
             catch (Exception e)

--- a/src/Engines/ExecuteRequestHandler.cs
+++ b/src/Engines/ExecuteRequestHandler.cs
@@ -103,8 +103,8 @@ namespace Microsoft.Jupyter.Core
             }
 
             // Invoke the onHandled callback prior to sending the execute_reply message.
-            // This guarantees that the OrderedShellHandler correctly clears this task from its
-            // currentTask reference *before* any new task that the client may submit for
+            // This guarantees that the OrderedShellHandler correctly processes the completion
+            // of this task *before* any processing new task that the client may submit for
             // execution immediately upon receiving the execute_reply message.
             onHandled();
 

--- a/src/ShellRouting/OrderedShellHandler.cs
+++ b/src/ShellRouting/OrderedShellHandler.cs
@@ -34,14 +34,22 @@ namespace Microsoft.Jupyter.Core
                 taskDepth++;
                 var previousTask = (Task<TResult?>?)state;
                 var previousResult = previousTask?.Result;
-                var currentResult = HandleAsync(message, previousResult, () =>
-                {                    
+
+                var handled = false;
+                Action onHandled = () =>
+                {
+                    handled = true;
                     taskDepth--;
                     if (taskDepth == 0)
                     {
                         currentTask = null;
                     }
-                }).Result;
+                };
+                var currentResult = HandleAsync(message, previousResult, onHandled).Result;
+                if (!handled)
+                {
+                    onHandled();
+                }
                 return currentResult;
             }, currentTask);
             currentTask.Start();

--- a/src/ShellRouting/OrderedShellHandler.cs
+++ b/src/ShellRouting/OrderedShellHandler.cs
@@ -37,8 +37,13 @@ namespace Microsoft.Jupyter.Core
                 // lock to ensure serial execution of tasks
                 lock (this)
                 {
-                    var previousResult = Interlocked.Equals(taskDepth, 1) ? null : previousTask?.Result;
-                    return HandleAsync(message, previousResult, () => Interlocked.Decrement(ref taskDepth)).Result;
+                    return HandleAsync(message, previousTask?.Result, () =>
+                    {
+                        if (Interlocked.Decrement(ref taskDepth) == 0)
+                        {
+                            currentTask = null;
+                        }
+                    }).Result;
                 }
             });
             currentTask.Start();

--- a/src/ShellRouting/OrderedShellHandler.cs
+++ b/src/ShellRouting/OrderedShellHandler.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Jupyter.Core
                 // lock to ensure serial execution of tasks
                 lock (this)
                 {
-                    var previousResult = Interlocked.Equals(taskDepth, 0) ? null : previousTask?.Result;
+                    var previousResult = Interlocked.Equals(taskDepth, 1) ? null : previousTask?.Result;
                     return HandleAsync(message, previousResult, () => Interlocked.Decrement(ref taskDepth)).Result;
                 }
             });


### PR DESCRIPTION
This PR fixes a potential timing issue for clients that issue commands sequentially.

The `OrderedShellHandler` is used in order to cause pending cell executions to be aborted whenever the current cell execution fails. This is for the scenario where a bunch of notebook cells are executed quickly -- if one fails, we want to cancel the execution of the rest of the cells.

However, if a client is triggering new cell executions immediately after the previous one finishes (which happens, e.g. when executing a notebook using `jupyter nbconvert`, or when the IQ# kernel is being driven from Python), there is a race condition where the previous cell's failure may cause the new cell execution to be aborted (even though it was not queued until after the failure of the first one).

The fix is to ensure that `OrderedShellHandler` processes the completion of a cell _before_ sending the `execute_reply` message back to the client.

This is required for addressing https://github.com/microsoft/iqsharp/issues/310. IQ# will then need to consume a new release of Microsoft.Jupyter.Core containing this fix.