### PR TITLE
Messaging fixes for nteract and Jupyter Lab clients

### DIFF
--- a/src/Data/Protocol.cs
+++ b/src/Data/Protocol.cs
@@ -171,6 +171,16 @@ namespace Microsoft.Jupyter.Core.Protocol
     }
 
     [JsonObject(MemberSerialization.OptIn)]
+    public class ExecuteInputContent : MessageContent
+    {
+        [JsonProperty("code")]
+        public string Code { get; set; }
+
+        [JsonProperty("execution_count")]
+        public int ExecutionCount { get; set; }
+    }
+
+    [JsonObject(MemberSerialization.OptIn)]
     public class ExecuteReplyContent : MessageContent
     {
         [JsonProperty("status")]

--- a/src/Engines/BaseEngine.cs
+++ b/src/Engines/BaseEngine.cs
@@ -454,6 +454,21 @@ namespace Microsoft.Jupyter.Core
                         }
                     }
                 );
+
+                // Finish by telling the client that we're free.
+                this.ShellServer.SendIoPubMessage(
+                    new Message
+                    {
+                        Header = new MessageHeader
+                        {
+                            MessageType = "status"
+                        },
+                        Content = new KernelStatusContent
+                        {
+                            ExecutionState = ExecutionState.Idle
+                        }
+                    }.AsReplyTo(message)
+                );
             }
             catch (Exception e)
             {


### PR DESCRIPTION
Fixes #35 by sending an `execute_input` message immediately after receiving a cell execution request.

Fixes #66 by sending a `status` message immediately after sending a kernel info reply to let the client know that the kernel is idle and ready.