### PR TITLE
Allow custom MIME type for JSON data

### DIFF
--- a/src/Engines/BaseEngine.cs
+++ b/src/Engines/BaseEngine.cs
@@ -289,7 +289,24 @@ namespace Microsoft.Jupyter.Core
         ///      into JSON.
         /// </param>
         public void RegisterJsonEncoder(params JsonConverter[] converters) =>
-            RegisterDisplayEncoder(new JsonResultEncoder(this.Logger, converters));
+            RegisterJsonEncoder(null, converters);
+
+        /// <summary>
+        ///      Adds a new result encoder that serializes its output to JSON.
+        ///      Serialization failures are logged, but are not written out
+        ///      as results or displayed.
+        /// </summary>
+        /// <param name="mimeType">
+        ///      MIME type string to be used for this encoded output in the
+        ///      execution result. If null, a default of "application/json"
+        ///      will be used.
+        /// </param>
+        /// <param name="converters">
+        ///      Additional JSON converters to be used when serializing results
+        ///      into JSON.
+        /// </param>
+        public void RegisterJsonEncoder(string mimeType, params JsonConverter[] converters) =>
+            RegisterDisplayEncoder(new JsonResultEncoder(this.Logger, converters, mimeType));
 
         /// <summary>
         ///      Registers a default set of result encoders that is sufficient

--- a/src/ResultEncoding/BasicEncoders.cs
+++ b/src/ResultEncoding/BasicEncoders.cs
@@ -12,13 +12,15 @@ namespace Microsoft.Jupyter.Core
     {
         private readonly ILogger logger;
         private readonly JsonConverter[] converters;
+        private readonly string mimeType;
 
-        public string MimeType => MimeTypes.Json;
+        public string MimeType => mimeType;
 
-        public JsonResultEncoder(ILogger logger = null, JsonConverter[] converters = null)
+        public JsonResultEncoder(ILogger logger = null, JsonConverter[] converters = null, string mimeType = null)
         {
             this.logger = logger;
             this.converters = converters ?? new JsonConverter[] {};
+            this.mimeType = mimeType ?? MimeTypes.Json;
         }
 
         public EncodedData? Encode(object displayable)


### PR DESCRIPTION
To address issues such as https://github.com/microsoft/iqsharp/issues/34, kernels may need to specify a custom MIME type for JSON-encoded result data. This PR allows kernels to override the default MIME type for JSON-encoded result data.

This is needed because kernels would typically want the HTML-encoded data to be displayed in a browser context, but some Jupyter clients (such as Jupyter Lab and nteract) will prioritize display of data labeled with MIME type `application/json` over data labeled with MIME type `text/html`. Using a custom MIME type for the JSON-encoded data will cause the HTML-encoded data to be displayed in these clients, as desired.