### PR TITLE
Add new task for engine initialization

### DIFF
--- a/src/Engines/BaseEngine.cs
+++ b/src/Engines/BaseEngine.cs
@@ -427,6 +427,13 @@ namespace Microsoft.Jupyter.Core
 
         #region Lifecycle
 
+        /// <summary>
+        ///     Task that completes when and only when the engine is fully
+        ///     ready to execute inputs. After awaiting this task, the engine
+        ///     is guaranteed to be fully initialized.
+        /// </summary>
+        public virtual Task Initialized => Task.CompletedTask;
+
         public virtual void Start()
         {
             if (this.ShellServer is IShellServerSupportsInterrupt shellServerSupportsInterrupt)

--- a/src/Engines/ExecuteRequestHandler.cs
+++ b/src/Engines/ExecuteRequestHandler.cs
@@ -81,6 +81,9 @@ namespace Microsoft.Jupyter.Core
                     shellServerSupportsInterrupt.InterruptRequest += onInterruptRequest;
                 }
 
+                // Make sure that the engine is fully initialized.
+                await engine.Initialized;
+
                 try
                 {
                     engineResponse = await engine.Execute(

--- a/src/Engines/IExecutionEngine.cs
+++ b/src/Engines/IExecutionEngine.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Text;
+using System.Threading.Tasks;
 
 namespace Microsoft.Jupyter.Core
 {

--- a/src/KernelApplication.cs
+++ b/src/KernelApplication.cs
@@ -636,22 +636,6 @@ namespace Microsoft.Jupyter.Core
                 var engine = serviceProvider.GetService<IExecutionEngine>();
                 logger.LogDebug("Starting engine service.");
                 engine.Start();
-
-                // Once finished, have the shell server report that we are
-                // idle.
-                shellServer.SendIoPubMessage(
-                    new Message
-                    {
-                        Header = new MessageHeader
-                        {
-                            MessageType = "status"
-                        },
-                        Content = new KernelStatusContent
-                        {
-                            ExecutionState = ExecutionState.Idle
-                        }
-                    }
-                );
             }
 
             KernelStarted?.Invoke(serviceProvider);

--- a/src/Servers/ShellServer.cs
+++ b/src/Servers/ShellServer.cs
@@ -182,6 +182,7 @@ namespace Microsoft.Jupyter.Core
                             ExecutionState = ExecutionState.Busy
                         }
                     }
+                    .AsReplyTo(message)
                 );
 
                 this.SendShellMessage(
@@ -214,6 +215,7 @@ namespace Microsoft.Jupyter.Core
                             ExecutionState = ExecutionState.Idle
                         }
                     }
+                    .AsReplyTo(message)
                 );
             }
             catch (Exception e)

--- a/src/Servers/ShellServer.cs
+++ b/src/Servers/ShellServer.cs
@@ -169,6 +169,21 @@ namespace Microsoft.Jupyter.Core
 
             try
             {
+                // Tell the client we're about to handle their kernel_info_request.
+                this.SendIoPubMessage(
+                    new Message
+                    {
+                        Header = new MessageHeader
+                        {
+                            MessageType = "status"
+                        },
+                        Content = new KernelStatusContent
+                        {
+                            ExecutionState = ExecutionState.Busy
+                        }
+                    }
+                );
+
                 this.SendShellMessage(
                     new Message
                     {
@@ -181,6 +196,22 @@ namespace Microsoft.Jupyter.Core
                             MessageType = "kernel_info_reply",
                             Id = Guid.NewGuid().ToString(),
                             ProtocolVersion = "5.2.0"
+                        }
+                    }
+                );
+
+                // Once finished, have the shell server report that we are
+                // idle.
+                this.SendIoPubMessage(
+                    new Message
+                    {
+                        Header = new MessageHeader
+                        {
+                            MessageType = "status"
+                        },
+                        Content = new KernelStatusContent
+                        {
+                            ExecutionState = ExecutionState.Idle
                         }
                     }
                 );


### PR DESCRIPTION
This PR (see discussion at https://github.com/microsoft/iqsharp/pull/389) allows  engines to provide a task that is completed on engine initialization, so that initialization work can be deferred to background threads without blocking shell message handling. The shell server then waits on this new task when engine initialization is required (that is, when an execute request is received).