### PR TITLE
Don't treat cancellation exceptions as errors.

### DIFF
--- a/src/Engines/BaseEngine.cs
+++ b/src/Engines/BaseEngine.cs
@@ -607,6 +607,11 @@ namespace Microsoft.Jupyter.Core
                 // Return the most recently-obtained result.
                 return result;
             }
+            catch (TaskCanceledException)
+            {
+                // Do nothing; it's OK for a task to be cancelled.
+                return (null as object).ToExecutionResult();
+            }
             catch (Exception e)
             {
                 Logger.LogWarning(e, $"Exception encountered when executing input: ${input}");

--- a/src/Engines/ExecuteRequestHandler.cs
+++ b/src/Engines/ExecuteRequestHandler.cs
@@ -240,6 +240,15 @@ namespace Microsoft.Jupyter.Core
                 var result = await ExecutionTaskForMessage(message, executionCount, onHandled);
                 return result;
             }
+            catch (TaskCanceledException tce)
+            {
+                this.logger?.LogDebug(tce, "Task cancelled.");
+                return new ExecutionResult
+                {
+                    Output = null,
+                    Status = ExecuteStatus.Abort
+                };
+            }
             catch (Exception e)
             {
                 this.logger?.LogError(e, "Unable to process ExecuteRequest");


### PR DESCRIPTION
This PR modifies exception handling to exempt task cancellation exceptions from try/catch blocks intended to catch actual errors. In particular, task cancellation exceptions can arise during normal and correct operation, such that they should not be reported out to the end user as errors. This change thus implies that when a user interrupts execution, no error message is displayed in the notebook output.