### PR TITLE
Update build schedule

### DIFF
--- a/ci/ci.yml
+++ b/ci/ci.yml
@@ -7,7 +7,7 @@ schedules:
   displayName: 'Build for Component Governance'
   branches:
     include:
-    - main
+    - master
   always: true
 
 resources:

--- a/ci/ci.yml
+++ b/ci/ci.yml
@@ -1,6 +1,15 @@
 name: $(Build.Major).$(Build.Minor).$(BuildId)
 trigger:
 - master
+
+schedules:
+- cron: "0 9 * * Sat"
+  displayName: 'Build for Component Governance'
+  branches:
+    include:
+    - main
+  always: true
+
 resources:
   repositories:
   - repository: self


### PR DESCRIPTION
Add a scheduled build to keep component governance detection current.