### PR TITLE
Add support for custom messaging via Jupyter comms.

### DIFF
--- a/src/Data/Protocol.cs
+++ b/src/Data/Protocol.cs
@@ -3,6 +3,7 @@
 
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
+using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
@@ -66,15 +67,21 @@ namespace Microsoft.Jupyter.Core.Protocol
         // FIXME: make not just an object.
         public MessageContent Content { get; set; }
 
+        public Message WithSessionFrom(Message parent)
+        {
+            var reply = this.MemberwiseClone() as Message;
+            reply.ZmqIdentities = parent.ZmqIdentities;
+            reply.Header.Session = parent.Header.Session;
+            return reply;
+        }
+
         public Message AsReplyTo(Message parent)
         {
             // No parent, just return
             if (parent == null) return this;
 
-            var reply = this.MemberwiseClone() as Message;
-            reply.ZmqIdentities = parent.ZmqIdentities;
+            var reply = this.WithSessionFrom(parent);
             reply.ParentHeader = parent.Header;
-            reply.Header.Session = parent.Header.Session;
             return reply;
         }
 
@@ -89,7 +96,10 @@ namespace Microsoft.Jupyter.Core.Protocol
                 ["kernel_info_request"] = data => new EmptyContent(),
                 ["execute_request"] = data => JsonConvert.DeserializeObject<ExecuteRequestContent>(data),
                 ["interrupt_request"] = data => new EmptyContent(),
-                ["shutdown_request"] = data => JsonConvert.DeserializeObject<ShutdownRequestContent>(data)
+                ["shutdown_request"] = data => JsonConvert.DeserializeObject<ShutdownRequestContent>(data),
+                ["comm_open"] = data => JsonConvert.DeserializeObject<CommOpenContent>(data),
+                ["comm_msg"] = data => JsonConvert.DeserializeObject<CommMessageContent>(data),
+                ["comm_close"] = data => JsonConvert.DeserializeObject<CommCloseContent>(data)
             }.ToImmutableDictionary();
     }
 
@@ -101,7 +111,20 @@ namespace Microsoft.Jupyter.Core.Protocol
     [JsonObject(MemberSerialization.OptIn)]
     public class UnknownContent : MessageContent
     {
-        public Dictionary<string, object> Data { get; set; }
+        public Dictionary<string, object> Data
+        {
+            get
+            {
+                return RawData.ToObject<Dictionary<string, object>>();
+            }
+
+            set
+            {
+                RawData = JToken.FromObject(value);
+            }
+        }
+
+        public JToken RawData { get; set; }
     }
 
     [JsonObject(MemberSerialization.OptIn)]
@@ -233,6 +256,39 @@ namespace Microsoft.Jupyter.Core.Protocol
 
         [JsonProperty("transient", NullValueHandling=NullValueHandling.Ignore)]
         public TransientDisplayData Transient { get; set; } = null;
+    }
+
+    [JsonObject(MemberSerialization.OptIn)]
+    public class CommOpenContent : MessageContent
+    {
+        [JsonProperty("comm_id")]
+        public string Id { get; set; }
+
+        [JsonProperty("target_name")]
+        public string TargetName { get; set; }
+
+        [JsonProperty("data", NullValueHandling = NullValueHandling.Ignore)]
+        public JToken RawData { get; set; } = JToken.FromObject(null);
+    }
+
+    [JsonObject]
+    public class CommMessageContent : MessageContent
+    {
+        [JsonProperty("comm_id")]
+        public string Id { get; set; }
+
+        [JsonProperty("data")]
+        public JToken RawData { get; set; } = JToken.FromObject(null);
+    }
+
+    [JsonObject(MemberSerialization.OptIn)]
+    public class CommCloseContent : MessageContent
+    {
+        [JsonProperty("comm_id")]
+        public string Id { get; set; }
+
+        [JsonProperty("data")]
+        public JToken RawData { get; set; } = JToken.FromObject(null);
     }
 
 }

--- a/src/Data/Protocol.cs
+++ b/src/Data/Protocol.cs
@@ -268,7 +268,7 @@ namespace Microsoft.Jupyter.Core.Protocol
         public string TargetName { get; set; }
 
         [JsonProperty("data", NullValueHandling = NullValueHandling.Ignore)]
-        public JToken RawData { get; set; } = JToken.FromObject(null);
+        public JToken RawData { get; set; } = null;
     }
 
     [JsonObject]
@@ -278,7 +278,7 @@ namespace Microsoft.Jupyter.Core.Protocol
         public string Id { get; set; }
 
         [JsonProperty("data")]
-        public JToken RawData { get; set; } = JToken.FromObject(null);
+        public JToken RawData { get; set; } = null;
     }
 
     [JsonObject(MemberSerialization.OptIn)]
@@ -288,7 +288,7 @@ namespace Microsoft.Jupyter.Core.Protocol
         public string Id { get; set; }
 
         [JsonProperty("data")]
-        public JToken RawData { get; set; } = JToken.FromObject(null);
+        public JToken RawData { get; set; } = null;
     }
 
 }

--- a/src/Extensions/Extensions.cs
+++ b/src/Extensions/Extensions.cs
@@ -37,6 +37,7 @@ namespace Microsoft.Jupyter.Core
                 converted = null;
                 return false;
             }
+        }
 
         internal static void NotifyBusyStatus(this IShellServer shellServer, Message message, ExecutionState state)
         {

--- a/src/Extensions/Extensions.cs
+++ b/src/Extensions/Extensions.cs
@@ -9,6 +9,7 @@ using Newtonsoft.Json;
 using System.Collections.Generic;
 using System.Security.Cryptography;
 using System;
+using Newtonsoft.Json.Linq;
 
 namespace Microsoft.Jupyter.Core
 {
@@ -17,5 +18,24 @@ namespace Microsoft.Jupyter.Core
     /// </summary>
     public static partial class Extensions
     {
+        /// <summary>
+        ///      Given some raw data, attempts to decode it into an object of
+        ///      a given type, returning <c>false</c> if the deserialization
+        ///      fails.
+        /// </summary>
+        public static bool TryAs<T>(this JToken rawData, out T converted)
+        where T: class
+        {
+            try
+            {
+                converted = rawData.ToObject<T>();
+                return true;
+            }
+            catch
+            {
+                converted = null;
+                return false;
+            }
+        }
     }
 }

--- a/src/Extensions/Messages.cs
+++ b/src/Extensions/Messages.cs
@@ -10,6 +10,7 @@ using System.Collections.Generic;
 using System.Security.Cryptography;
 using System;
 using Microsoft.Jupyter.Core.Protocol;
+using Newtonsoft.Json.Linq;
 
 namespace Microsoft.Jupyter.Core
 {
@@ -84,7 +85,7 @@ namespace Microsoft.Jupyter.Core
                 data =>
                     new UnknownContent
                     {
-                        Data = JsonConvert.DeserializeObject<Dictionary<string, object>>(data)
+                        RawData = JToken.Parse(data)
                     }
             )(frames[idxDelimiter + 5]);
 

--- a/src/Extensions/ServiceCollection.cs
+++ b/src/Extensions/ServiceCollection.cs
@@ -23,7 +23,8 @@ namespace Microsoft.Jupyter.Core
             serviceCollection
                 .AddSingleton<IHeartbeatServer, HeartbeatServer>()
                 .AddSingleton<IShellServer, ShellServer>()
-                .AddSingleton<IShellRouter, ShellRouter>();
+                .AddSingleton<IShellRouter, ShellRouter>()
+                .AddSingleton<ICommsRouter, CommsRouter>();
 
             return serviceCollection;
         }

--- a/src/ShellRouting/CommsRouter.cs
+++ b/src/ShellRouting/CommsRouter.cs
@@ -41,6 +41,7 @@ namespace Microsoft.Jupyter.Core
 
             internal CommSession(CommsRouter commsRouter, string id)
             {
+                this.IsValid = true;
                 this.commsRouter = commsRouter;
                 this.Id = id;
             }
@@ -258,7 +259,7 @@ namespace Microsoft.Jupyter.Core
 
         internal Task SendMessage(Message messsage)
         {
-            this.Server.SendShellMessage(messsage);
+            this.Server.SendIoPubMessage(messsage);
             return Task.CompletedTask;
         }
 

--- a/src/ShellRouting/CommsRouter.cs
+++ b/src/ShellRouting/CommsRouter.cs
@@ -117,10 +117,10 @@ namespace Microsoft.Jupyter.Core
 
         private class CommSessionOpen : ICommSessionOpen
         {
-            public event Action<ICommSession>? On = null;
+            public event Func<ICommSession, JToken, Task>? On = null;
 
-            internal void Handle(ICommSession session) =>
-                On?.Invoke(session);
+            internal async Task Handle(ICommSession session, JToken data) =>
+                await (On?.Invoke(session, data) ?? Task.CompletedTask);
         }
 
         #endregion
@@ -155,7 +155,7 @@ namespace Microsoft.Jupyter.Core
                     {
                         var session = new CommSession(this, openContent.Id);
                         openSessions.Add(session.Id, session);
-                        handler.Handle(session);
+                        await handler.Handle(session, openContent.RawData);
                     }
                     else
                     {

--- a/src/ShellRouting/CommsRouter.cs
+++ b/src/ShellRouting/CommsRouter.cs
@@ -1,0 +1,280 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Net;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Microsoft.Jupyter.Core.Protocol;
+using Newtonsoft.Json.Linq;
+
+#nullable enable
+
+namespace Microsoft.Jupyter.Core
+{
+    /// <inheritdoc />
+    public class CommsRouter : ICommsRouter
+    {
+
+        #region Inner Classes
+        
+        /// <inheritdoc />
+        public class CommSession : ICommSession, IDisposable
+        {
+            /// <inheritdoc />
+            public event Func<CommMessageContent, Task>? OnMessage;
+
+            /// <inheritdoc />
+            public event Func<CommSessionClosedBy, Task>? OnClose;
+
+
+            /// <inheritdoc />
+            public bool IsValid { get; private set; }
+
+            /// <inheritdoc />
+            public string Id { get; private set; }
+
+            private readonly CommsRouter commsRouter;
+
+
+            internal CommSession(CommsRouter commsRouter, string id)
+            {
+                this.commsRouter = commsRouter;
+                this.Id = id;
+            }
+
+            /// <inheritdoc />
+            public async Task SendMessage(object contents)
+            {
+                if (!IsValid)
+                {
+                    throw new ProtocolViolationException(
+                        "Attempted to send a message on a comms session that has been closed or disposed. " +
+                        "If you did not close this comms session, it may have been closed from the client. " +
+                        "You can subscribe to the OnClose event of this session to check for closures coming from the client."
+                    );
+                }
+
+                var messsage = new Message
+                {
+                    Header = new MessageHeader
+                    {
+                        MessageType = "comm_msg"
+                    },
+                    Content = new CommMessageContent
+                    {
+                        Id = this.Id,
+                        RawData = JToken.FromObject(contents)
+                    }
+                };
+                await this.commsRouter.SendMessage(messsage);
+            }
+
+            internal async Task HandleClose(CommSessionClosedBy closedBy)
+            {
+                Debug.Assert(IsValid);
+                IsValid = false;
+                await (this.OnClose?.Invoke(closedBy) ?? Task.CompletedTask);
+            }
+
+            internal async Task HandleMessage(CommMessageContent content)
+            {
+                Debug.Assert(IsValid);
+                await (this.OnMessage?.Invoke(content) ?? Task.CompletedTask);
+            }
+
+            /// <inheritdoc />
+            public async Task Close()
+            {
+                // Make Close idempotent; that is, closing a closed session should
+                // do nothing.
+                if (!IsValid)
+                {
+                    return;
+                }
+
+                var message = new Message
+                {
+                    Header = new MessageHeader
+                    {
+                        MessageType = "comm_close"
+                    },
+                    Content = new CommCloseContent
+                    {
+                        Id = this.Id
+                    }
+                };
+
+                await this.commsRouter.SendMessage(message);
+                await HandleClose(closedBy: CommSessionClosedBy.Kernel);
+            }
+
+            void IDisposable.Dispose() => Close().Wait();
+        }
+
+        private class CommSessionOpen : ICommSessionOpen
+        {
+            public event Action<ICommSession>? On = null;
+
+            internal void Handle(ICommSession session) =>
+                On?.Invoke(session);
+        }
+
+        #endregion
+
+        private readonly Dictionary<string, CommSession> openSessions
+            = new Dictionary<string, CommSession>();
+
+        private readonly Dictionary<string, CommSessionOpen> sessionHandlers
+            = new Dictionary<string, CommSessionOpen>();
+
+        private IShellServer Server { get; set; }
+
+        private IShellRouter Router { get; set; }
+
+        private ILogger<CommsRouter>? logger;
+
+        /// <summary>
+        ///      Constructs a new comms router, given services required by the
+        ///      new router.
+        /// </summary>
+        public CommsRouter(IShellServer server, IShellRouter router, ILogger<CommsRouter>? logger = null)
+        {
+            this.Server = server;
+            this.Router = router;
+            this.logger = logger;
+
+            router.RegisterHandler("comm_open", async (message) =>
+            {
+                if (message.Content is CommOpenContent openContent)
+                {
+                    if (sessionHandlers.TryGetValue(openContent.TargetName, out var handler))
+                    {
+                        var session = new CommSession(this, openContent.Id);
+                        openSessions.Add(session.Id, session);
+                        handler.Handle(session);
+                    }
+                    else
+                    {
+                        // According to the Jupyter messaging protocol, we are
+                        // supposed to ignore comm_open messages entirely if
+                        // we don't recognizer the target_name property.
+                        logger.LogWarning(
+                            "Got a comm_open message for target name {TargetName}, but no handler for that target name has been registered.",
+                            openContent.TargetName
+                        );
+                    }
+                }
+                else
+                {
+                    logger.LogError(
+                        "Expected message content for a comm_open message, but got content of type {Type} instead.",
+                        message.Content.GetType()
+                    );
+                }
+            });
+
+            router.RegisterHandler("comm_msg", async (message) =>
+            {
+                if (message.Content is CommMessageContent msgContent)
+                {
+                    if (!openSessions.TryGetValue(msgContent.Id, out var session))
+                    {
+                        logger.LogError(
+                            "Got comms message for session {Id}, but no such session is currently open.",
+                            session.Id
+                        );
+                    }
+                    await session.HandleMessage(msgContent);
+                }
+                else
+                {
+                    logger.LogError(
+                        "Expected message content for a comm_msg message, but got content of type {Type} instead.",
+                        message.Content.GetType()
+                    );
+                }
+            });
+
+            router.RegisterHandler("comm_close", async (message) =>
+            {
+                if (message.Content is CommCloseContent closeContent)
+                {
+                    if (!openSessions.TryGetValue(closeContent.Id, out var session))
+                    {
+                        logger.LogError(
+                            "Asked by client to close comms session with {Id}, but no such session is currently open.",
+                            session.Id
+                        );
+                    }
+                    openSessions.Remove(session.Id);
+                    await session.HandleClose(CommSessionClosedBy.Client);
+                }
+                else
+                {
+                    logger.LogError(
+                        "Expected message content for a comm_close message, but got content of type {Type} instead.",
+                        message.Content.GetType()
+                    );
+                }
+            });
+        }
+
+        /// <inheritdoc />
+        public async Task<ICommSession> OpenSession(string targetName, object? data = null)
+        {
+            var id = Guid.NewGuid().ToString();
+            var commSession = new CommSession(this, id);
+            openSessions.Add(id, commSession);
+
+            await SendMessage(new Message
+            {
+                Content = new CommOpenContent
+                {
+                    RawData = data == null ? null : JToken.FromObject(data),
+                    Id = id,
+                    TargetName = targetName
+                },
+                Header = new MessageHeader
+                {
+                    MessageType = "comm_open"
+                }
+            });
+
+            return commSession;
+        }
+
+        internal void RemoveSession(CommSession session)
+        {
+            Debug.Assert(
+                openSessions.ContainsKey(session.Id),
+                "Attempted to remove a session that was not still open. " +
+                "This is an internal error that should never happen."
+            );
+            openSessions.Remove(session.Id);
+        }
+
+        internal Task SendMessage(Message messsage)
+        {
+            this.Server.SendShellMessage(messsage);
+            return Task.CompletedTask;
+        }
+
+        /// <inheritdoc />
+        public ICommSessionOpen SessionOpenEvent(string targetName)
+        {
+            if (sessionHandlers.TryGetValue(targetName, out var handler))
+            {
+                return handler;
+            }
+            else
+            {
+                var newHandler = new CommSessionOpen();
+                sessionHandlers.Add(targetName, newHandler);
+                return newHandler;
+            }
+        }
+    }
+}

--- a/src/ShellRouting/ICommsRouter.cs
+++ b/src/ShellRouting/ICommsRouter.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Threading.Tasks;
 using Microsoft.Jupyter.Core.Protocol;
+using Newtonsoft.Json.Linq;
 
 namespace Microsoft.Jupyter.Core
 {
@@ -55,7 +56,7 @@ namespace Microsoft.Jupyter.Core
 
     public interface ICommSessionOpen
     {
-        event Action<ICommSession>? On;
+        event Func<ICommSession, JToken, Task>? On;
     }
 
     public interface ICommsRouter

--- a/src/ShellRouting/ICommsRouter.cs
+++ b/src/ShellRouting/ICommsRouter.cs
@@ -1,0 +1,68 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#nullable enable
+
+using System;
+using System.Threading.Tasks;
+using Microsoft.Jupyter.Core.Protocol;
+
+namespace Microsoft.Jupyter.Core
+{
+
+    public enum CommSessionClosedBy
+    {
+        Client,
+        Kernel,
+    }
+
+    public interface ICommSession
+    {
+        /// <summary>
+        ///     Raised when a new message is available from the client.
+        /// </summary>
+        event Func<CommMessageContent, Task>? OnMessage;
+
+        /// <summary>
+        ///     Raised when this session is closed, whether by the kernel or
+        ///     by the client.
+        /// </summary>
+        event Func<CommSessionClosedBy, Task>? OnClose;
+
+        /// <summary>
+        ///     If <c>true</c>, then this session is still open and can be used
+        ///     to send and receive comms messages.
+        /// </summary>
+        bool IsValid { get; }
+
+        /// <summary>
+        ///     A unique ID identifying this session as part of a larger Jupyter
+        ///     messaging session.
+        /// </summary>
+        string Id { get; }
+
+        /// <summary>
+        ///     Sends a comm message to the client.
+        /// </summary>
+        Task SendMessage(object contents);
+
+        /// <summary>
+        ///     Closes this comm session, notifying the client if the session
+        ///     was not already closed.
+        /// </summary>
+        Task Close();
+    }
+
+    public interface ICommSessionOpen
+    {
+        event Action<ICommSession>? On;
+    }
+
+    public interface ICommsRouter
+    {
+        ICommSessionOpen SessionOpenEvent(string targetName);
+
+        Task<ICommSession> OpenSession(string targetName, object? data);
+
+    }
+}


### PR DESCRIPTION
This PR adds support for the `comm_msg`, `comm_open`, and `comm_close` messages, allowing for kernels to more easily define custom communications back and forth with clients.